### PR TITLE
Added basic Bstats Analytics

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
         exclude(group = "com.sun.xml.bind", module = "jaxb-xjc") // Else Remapping will yell of duplicated classes
     }
     implementation(libs.com.googlecode.json.simple)
+    implementation(libs.bstats.bukkit)
     implementation(platform(libs.fawe.bom))
     compileOnly("com.fastasyncworldedit:FastAsyncWorldEdit-Core")
     compileOnly("com.fastasyncworldedit:FastAsyncWorldEdit-Bukkit") { isTransitive = false }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ com-gradleup-shadow = "9.3.1" # https://github.com/GradleUp/shadow/releases
 alpslib-io = "1.2.0" # https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/alpslib/alpslib-io/
 alpslib-utils = "1.4.0" # https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/alpslib/alpslib-utils/
 fawe-bom = "1.55" # Ref: https://github.com/IntellectualSites/bom
+bstats = "3.1.0" # https://central.sonatype.com/artifact/org.bstats/bstats-bukkit
 
 [libraries]
 com-alpsbte-alpslib-alpslib-libpsterra = { module = "com.alpsbte.alpslib:alpslib-libpsterra", version.ref = "com-alpsbte-alpslib-alpslib-libpsterra" }
@@ -37,6 +38,7 @@ com-googlecode-json-simple = { module = "com.googlecode.json-simple:json-simple"
 alpslib-io = { module = "com.alpsbte.alpslib:alpslib-io", version.ref = "alpslib-io" }
 alpslib-utils = { module = "com.alpsbte.alpslib:alpslib-utils", version.ref = "alpslib-utils" }
 fawe-bom = { module = "com.intellectualsites.bom:bom-newest", version.ref = "fawe-bom" }
+bstats-bukkit = { module = "org.bstats:bstats-bukkit", version.ref = "bstats" }
 
 [plugins]
 lombok = { id = "io.freefair.lombok", version.ref = "io-freefair-lombok" }

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/common/CommonModule.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/common/CommonModule.java
@@ -13,6 +13,7 @@ import net.buildtheearth.buildteamtools.modules.common.components.updater.Update
 import net.buildtheearth.buildteamtools.modules.common.components.version.VersionComponent;
 import net.buildtheearth.buildteamtools.modules.common.listeners.CommandListener;
 import net.buildtheearth.buildteamtools.modules.common.listeners.ExceptionListener;
+import net.buildtheearth.buildteamtools.modules.common.metrics.MetricsManager;
 import net.buildtheearth.buildteamtools.modules.generator.GeneratorModule;
 import net.buildtheearth.buildteamtools.modules.network.NetworkModule;
 import net.buildtheearth.buildteamtools.modules.stats.StatsModule;
@@ -75,6 +76,7 @@ public class CommonModule extends Module {
         dependencyComponent = new DependencyComponent();
         versionComponent = new VersionComponent();
 
+        MetricsManager.init(BuildTeamTools.getInstance());
 
         // Start the timer
         startTimer();

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/common/metrics/MetricsManager.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/common/metrics/MetricsManager.java
@@ -1,0 +1,13 @@
+package net.buildtheearth.buildteamtools.modules.common.metrics;
+
+import org.bstats.bukkit.Metrics;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class MetricsManager {
+
+    private static final int BSTATS_PLUGIN_ID = 29076;
+
+    public static void init(JavaPlugin plugin) {
+        new Metrics(plugin, BSTATS_PLUGIN_ID);
+    }
+}


### PR DESCRIPTION
I added the foundation for bStats analytics:
- Updated the dependencies
- Created the Metrics class
When the plugin is running on a server, statistics are automatically sent and updated on the bStats website.
https://bstats.org/plugin/bukkit/BuildTeamTools/29076