### PR TITLE
Add initial rail generator implementation

### DIFF
--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/commands/GeneratorCommand.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/commands/GeneratorCommand.java
@@ -3,24 +3,39 @@ package net.buildtheearth.buildteamtools.modules.generator.commands;
 import com.alpsbte.alpslib.utils.ChatHelper;
 import net.buildtheearth.buildteamtools.modules.generator.GeneratorModule;
 import net.buildtheearth.buildteamtools.modules.generator.menu.GeneratorMenu;
-import net.buildtheearth.buildteamtools.modules.generator.model.History;
+import net.buildtheearth.buildteamtools.modules.generator.model.HistoryEntry;
 import net.buildtheearth.buildteamtools.modules.network.model.Permissions;
 import net.buildtheearth.buildteamtools.utils.Utils;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-public class GeneratorCommand implements CommandExecutor {
+import java.util.ArrayList;
+import java.util.List;
 
+public class GeneratorCommand implements CommandExecutor, TabCompleter {
 
-    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String cmdLabel,
-                             String @NotNull [] args) {
+    private static final List<String> SUB_COMMANDS = List.of(
+            "house",
+            "road",
+            "rail",
+            "tree",
+            "field",
+            "history",
+            "undo",
+            "redo"
+    );
+
+    private static final List<String> HELP_ARGUMENTS = List.of("help", "info", "?");
+
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String cmdLabel, String @NotNull [] args) {
         if (!(sender instanceof Player p)) {
-            sender.sendMessage("§cOnly players can execute this command.");
+            sender.sendMessage(ChatHelper.PREFIX_COMPONENT.append(ChatHelper.getErrorComponent(
+                    "Only players can execute this command."
+            )));
             return true;
         }
 
@@ -29,55 +44,52 @@ public class GeneratorCommand implements CommandExecutor {
             return true;
         }
 
-        // Command Usage: /gen
         if (args.length == 0) {
             new GeneratorMenu(p, true);
             return true;
         }
 
-
-        // Command Usage: /gen house ...
-        switch (args[0]) {
+        switch (args[0].toLowerCase()) {
             case "house":
                 GeneratorModule.getInstance().getHouse().analyzeCommand(p, args);
                 return true;
 
-            // Command Usage: /gen road ...
             case "road":
                 GeneratorModule.getInstance().getRoad().analyzeCommand(p, args);
                 return true;
 
-            // Command Usage: /gen rail ...
             case "rail":
-                p.sendMessage(Component.text("This generator have some serious issues and is currently disabled.",
-                        NamedTextColor.DARK_RED));
-                //GeneratorModule.getInstance().getRail().analyzeCommand(p, args);
+                GeneratorModule.getInstance().getRail().analyzeCommand(p, args);
                 return true;
 
-            // Command Usage: /gen tree ...
             case "tree":
                 GeneratorModule.getInstance().getTree().analyzeCommand(p, args);
                 return true;
 
-            // Command Usage: /gen field ...
             case "field":
-                p.sendMessage(Component.text("This generator have some serious issues and is currently disabled.",
-                        NamedTextColor.DARK_RED));
-                //GeneratorModule.getInstance().getField().analyzeCommand(p, args);
+                p.sendMessage(ChatHelper.PREFIX_COMPONENT.append(ChatHelper.getErrorComponent(
+                        "This generator has serious issues and is currently disabled."
+                )));
                 return true;
 
-            // Command Usage: /gen history
             case "history":
                 if (GeneratorModule.getInstance().getPlayerHistory(p).getHistoryEntries().isEmpty()) {
-                    p.sendMessage("§cYou didn't generate any structures yet. Use /gen to create one.");
+                    p.sendMessage(ChatHelper.PREFIX_COMPONENT.append(ChatHelper.getErrorComponent(
+                            "You didn't generate any structures yet. Use /gen to create one."
+                    )));
                     return true;
                 }
 
                 ChatHelper.sendMessageBox(sender, "Generator History for " + p.getName(), () -> {
-                    for (History.HistoryEntry history : GeneratorModule.getInstance().getPlayerHistory(p).getHistoryEntries()) {
+                    for (HistoryEntry history : GeneratorModule.getInstance().getPlayerHistory(p).getHistoryEntries()) {
                         long timeDifference = System.currentTimeMillis() - history.getTimeCreated();
-                        p.sendMessage("§e- " + history.getGeneratorType().name() + " §7-§e " + Utils.toDate(timeDifference) +
-                                " ago §7-§e " + history.getWorldEditCommandCount() + " Commands executed");
+                        p.sendMessage(ChatHelper.getStandardComponent(
+                                false,
+                                "- %s - %s ago - %s Commands executed",
+                                history.getGeneratorType().name(),
+                                Utils.toDate(timeDifference),
+                                history.getWorldEditCommandCount()
+                        ));
                     }
                 });
                 return true;
@@ -89,6 +101,7 @@ public class GeneratorCommand implements CommandExecutor {
             case "redo":
                 GeneratorModule.getInstance().getPlayerHistory(p).redoCommand(p);
                 return true;
+
             default:
                 sendHelp(p);
                 return true;
@@ -97,17 +110,60 @@ public class GeneratorCommand implements CommandExecutor {
 
     public static void sendHelp(CommandSender sender) {
         ChatHelper.sendMessageBox(sender, "Generator Command", () -> {
-
-            sender.sendMessage("§eHouse Generator:§7 /gen house help");
-            sender.sendMessage("§eRoad Generator:§7 /gen road help");
-            sender.sendMessage("§eRail Generator:§7 /gen rail help");
-            sender.sendMessage("§eTree Generator:§7 /gen tree help");
-            sender.sendMessage("§eField Generator:§7 /gen field help");
-            sender.sendMessage("§7----------------------");
-            sender.sendMessage("§eGenerator History:§7 /gen history");
-            sender.sendMessage("§eUndo last command:§7 /gen undo");
-            sender.sendMessage("§eRedo last command:§7 /gen redo");
-
+            sender.sendMessage(ChatHelper.getStandardComponent(
+                    false,
+                    "Generators: %s, %s, %s, %s, %s",
+                    "/gen house help",
+                    "/gen road help",
+                    "/gen rail help",
+                    "/gen tree help",
+                    "/gen field help"
+            ));
+            sender.sendMessage(ChatHelper.getStandardComponent(
+                    false,
+                    "History: %s, %s, %s",
+                    "/gen history",
+                    "/gen undo",
+                    "/gen redo"
+            ));
         });
+    }
+
+    @Override
+    public List<String> onTabComplete(
+            @NotNull CommandSender sender,
+            @NotNull Command command,
+            @NotNull String label,
+            String @NotNull [] args
+    ) {
+        if (!sender.hasPermission(Permissions.GENERATOR_USE))
+            return List.of();
+
+        if (args.length == 1)
+            return getMatchingCompletions(SUB_COMMANDS, args[0]);
+
+        if (args.length == 2 && isGeneratorSubCommand(args[0]))
+            return getMatchingCompletions(HELP_ARGUMENTS, args[1]);
+
+        return List.of();
+    }
+
+    private boolean isGeneratorSubCommand(String value) {
+        return value.equalsIgnoreCase("house")
+                || value.equalsIgnoreCase("road")
+                || value.equalsIgnoreCase("rail")
+                || value.equalsIgnoreCase("tree")
+                || value.equalsIgnoreCase("field");
+    }
+
+    private List<String> getMatchingCompletions(List<String> options, String input) {
+        String normalizedInput = input.toLowerCase();
+        List<String> completions = new ArrayList<>();
+
+        for (String option : options)
+            if (option.startsWith(normalizedInput))
+                completions.add(option);
+
+        return completions;
     }
 }

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/house/House.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/house/House.java
@@ -17,7 +17,7 @@ public class House extends GeneratorComponent {
         if (GeneratorUtils.checkForNoWorldEditSelection(p))
             return false;
 
-        if (getPlayerSettings().get(p.getUniqueId()).getBlocks() == null) // Needed because block checks are made afterwards
+        if (getPlayerSettings().get(p.getUniqueId()).getBlocks() == null)
             getPlayerSettings().get(p.getUniqueId()).setBlocks(GeneratorUtils.analyzeRegion(p, p.getWorld()));
 
         Block[][][] blocks = getPlayerSettings().get(p.getUniqueId()).getBlocks();

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/PositionKey.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/PositionKey.java
@@ -1,0 +1,22 @@
+package net.buildtheearth.buildteamtools.modules.generator.components.rail;
+
+import org.bukkit.util.Vector;
+
+record PositionKey(int x, int y, int z) {
+
+    static PositionKey from(Vector vector) {
+        return new PositionKey(
+                vector.getBlockX(),
+                vector.getBlockY(),
+                vector.getBlockZ()
+        );
+    }
+
+    static PositionKey of(int x, int y, int z) {
+        return new PositionKey(x, y, z);
+    }
+
+    Vector toVector() {
+        return new Vector(x, y, z);
+    }
+}

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/Rail.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/Rail.java
@@ -1,27 +1,72 @@
 package net.buildtheearth.buildteamtools.modules.generator.components.rail;
 
+import com.alpsbte.alpslib.utils.ChatHelper;
 import com.alpsbte.alpslib.utils.GeneratorUtils;
+import com.sk89q.worldedit.regions.ConvexPolyhedralRegion;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import com.sk89q.worldedit.regions.Polygonal2DRegion;
+import com.sk89q.worldedit.regions.Region;
 import net.buildtheearth.buildteamtools.modules.generator.GeneratorModule;
 import net.buildtheearth.buildteamtools.modules.generator.model.GeneratorComponent;
 import net.buildtheearth.buildteamtools.modules.generator.model.GeneratorType;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class Rail extends GeneratorComponent {
 
+    private final Set<UUID> preparingPlayers = ConcurrentHashMap.newKeySet();
+
     public Rail() {
-        super(GeneratorType.RAILWAY);
+        super(GeneratorType.RAIL);
     }
 
     @Override
-    public boolean checkForPlayer(Player p) {
-        return !GeneratorUtils.checkForNoWorldEditSelection(p);
+    public boolean checkForPlayer(Player player) {
+        if (GeneratorUtils.checkForNoWorldEditSelection(player))
+            return false;
+
+        Region region = GeneratorUtils.getWorldEditSelection(player);
+
+        if (isSupportedRailSelection(region))
+            return true;
+
+        player.sendMessage(ChatHelper.PREFIX_COMPONENT.append(ChatHelper.getErrorComponent(
+                "Rail Generator supports cuboid, polygonal and convex WorldEdit selections."
+        )));
+        player.closeInventory();
+        player.playSound(player.getLocation(), Sound.ENTITY_ITEM_BREAK, 1.0F, 1.0F);
+        return false;
+    }
+
+    private boolean isSupportedRailSelection(Region region) {
+        return region instanceof CuboidRegion
+                || region instanceof Polygonal2DRegion
+                || region instanceof ConvexPolyhedralRegion;
     }
 
     @Override
-    public void generate(Player p) {
-        if (!GeneratorModule.getInstance().getRail().checkForPlayer(p))
+    public void generate(Player player) {
+        if (GeneratorModule.getInstance().isGenerating(player) || !preparingPlayers.add(player.getUniqueId())) {
+            sendAlreadyGeneratingMessage(player);
             return;
+        }
 
-        new RailScripts(p, this);
+        if (!GeneratorModule.getInstance().getRail().checkForPlayer(player)) {
+            preparingPlayers.remove(player.getUniqueId());
+            return;
+        }
+
+        new RailScripts(player, this, () -> preparingPlayers.remove(player.getUniqueId()));
+    }
+
+    private void sendAlreadyGeneratingMessage(Player player) {
+        player.sendMessage(ChatHelper.PREFIX_COMPONENT.append(ChatHelper.getErrorComponent(
+                "Rail Generator is already running. Please wait until the current generation is finished."
+        )));
+        player.playSound(player.getLocation(), Sound.ENTITY_ITEM_BREAK, 1.0F, 1.0F);
     }
 }

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailBlockBuilder.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailBlockBuilder.java
@@ -1,0 +1,268 @@
+package net.buildtheearth.buildteamtools.modules.generator.components.rail;
+
+import com.alpsbte.alpslib.utils.GeneratorUtils;
+import com.cryptomorin.xseries.XMaterial;
+import com.sk89q.worldedit.util.Direction;
+import com.sk89q.worldedit.world.block.BlockState;
+import com.sk89q.worldedit.world.block.BlockTypes;
+import org.bukkit.util.Vector;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+final class RailBlockBuilder {
+
+    private static final Direction DEFAULT_FACING = Direction.EAST;
+    private static final XMaterial[] CENTER_MATERIALS = new XMaterial[]{
+            XMaterial.DEAD_FIRE_CORAL_BLOCK,
+            XMaterial.STONE,
+            XMaterial.COBBLESTONE
+    };
+
+    private final List<Vector> controlPoints;
+    private final RailTerrainResolver terrainResolver;
+    private final RailType railType;
+    private final RailPreparationProgress preparationProgress;
+    private final int railLaneCount;
+    private final int railLaneSpacing;
+    private final long terrainAdjustedPercentage;
+    private final long buildFinishedPercentage;
+
+    RailBlockBuilder(
+            List<Vector> controlPoints,
+            RailTerrainResolver terrainResolver,
+            RailType railType,
+            RailPreparationProgress preparationProgress,
+            int railLaneCount,
+            int railLaneSpacing,
+            long terrainAdjustedPercentage,
+            long buildFinishedPercentage
+    ) {
+        this.controlPoints = controlPoints;
+        this.terrainResolver = terrainResolver;
+        this.railType = railType;
+        this.preparationProgress = preparationProgress;
+        this.railLaneCount = railLaneCount;
+        this.railLaneSpacing = railLaneSpacing;
+        this.terrainAdjustedPercentage = terrainAdjustedPercentage;
+        this.buildFinishedPercentage = buildFinishedPercentage;
+    }
+
+    Map<PositionKey, BlockState> build(List<Vector> path) {
+        Map<PositionKey, BlockState> railBlocks = new LinkedHashMap<>();
+        List<List<Vector>> railCenterPaths = new RailLanePathBuilder(controlPoints, terrainResolver, railLaneCount, railLaneSpacing)
+                .createRailCenterPaths(path);
+        Set<PositionKey> centerPositions = getCenterPositions(railCenterPaths);
+        Map<PositionKey, RailSideBlock> sideBlocks = new LinkedHashMap<>();
+        int totalPathPoints = getTotalPathPointCount(railCenterPaths);
+        int processedPathPoints = 0;
+
+        for (List<Vector> railCenterPath : railCenterPaths) {
+            for (int index = 0; index < railCenterPath.size(); index++) {
+                Vector center = railCenterPath.get(index);
+
+                for (RailSidePlacement sidePlacement : getSidePlacements(railCenterPath, index))
+                    addSideBlock(sideBlocks, center, sidePlacement, centerPositions);
+
+                processedPathPoints++;
+                preparationProgress.update(preparationProgress.scale(processedPathPoints, totalPathPoints, terrainAdjustedPercentage, 86L));
+            }
+        }
+
+        int processedSideBlocks = 0;
+
+        for (RailSideBlock sideBlock : sideBlocks.values()) {
+            railBlocks.put(sideBlock.key(), createAnvilBlockState(resolveSideBlockFacing(sideBlock, sideBlocks)));
+            processedSideBlocks++;
+            preparationProgress.update(preparationProgress.scale(processedSideBlocks, sideBlocks.size(), 86L, 89L));
+        }
+
+        int processedCenterPoints = 0;
+
+        for (List<Vector> railCenterPath : railCenterPaths) {
+            for (Vector center : railCenterPath) {
+                railBlocks.put(PositionKey.from(center), createCenterBlockState(center));
+                processedCenterPoints++;
+                preparationProgress.update(preparationProgress.scale(processedCenterPoints, totalPathPoints, 89L, buildFinishedPercentage));
+            }
+        }
+
+        return railBlocks;
+    }
+
+    private int getTotalPathPointCount(List<List<Vector>> railCenterPaths) {
+        int totalPathPoints = 0;
+
+        for (List<Vector> railCenterPath : railCenterPaths)
+            totalPathPoints += railCenterPath.size();
+
+        return Math.max(1, totalPathPoints);
+    }
+
+    private List<RailSidePlacement> getSidePlacements(List<Vector> path, int index) {
+        List<RailSidePlacement> placements = new ArrayList<>();
+        Vector center = path.get(index);
+        RailStep previousStep = index > 0 ? getStep(path.get(index - 1), center) : null;
+        RailStep nextStep = index < path.size() - 1 ? getStep(center, path.get(index + 1)) : null;
+
+        addSidePlacements(placements, getRailStep(path, index, new RailStep(1, 0)));
+
+        if (previousStep != null)
+            addSidePlacements(placements, previousStep);
+
+        if (nextStep != null)
+            addSidePlacements(placements, nextStep);
+
+        return placements;
+    }
+
+    private void addSidePlacements(List<RailSidePlacement> placements, RailStep step) {
+        if (step.dx() != 0 && step.dz() != 0) {
+            addSidePlacement(placements, new RailStep(step.dx(), 0), GeneratorUtils.getFacing(0, step.dz(), DEFAULT_FACING));
+            addSidePlacement(placements, new RailStep(0, step.dz()), GeneratorUtils.getFacing(step.dx(), 0, DEFAULT_FACING));
+            return;
+        }
+
+        if (step.dx() != 0) {
+            Direction facing = GeneratorUtils.getFacing(step.dx(), 0, DEFAULT_FACING);
+            addSidePlacement(placements, new RailStep(0, 1), facing);
+            addSidePlacement(placements, new RailStep(0, -1), facing);
+            return;
+        }
+
+        Direction facing = GeneratorUtils.getFacing(0, step.dz(), DEFAULT_FACING);
+        addSidePlacement(placements, new RailStep(1, 0), facing);
+        addSidePlacement(placements, new RailStep(-1, 0), facing);
+    }
+
+    private void addSidePlacement(List<RailSidePlacement> placements, RailStep offset, Direction facing) {
+        for (RailSidePlacement placement : placements) {
+            if (placement.offset().equals(offset)) return;
+        }
+
+        placements.add(new RailSidePlacement(offset, facing));
+    }
+
+    private void addSideBlock(
+            Map<PositionKey, RailSideBlock> sideBlocks,
+            Vector center,
+            RailSidePlacement sidePlacement,
+            Set<PositionKey> centerPositions
+    ) {
+        RailStep sideOffset = sidePlacement.offset();
+
+        if (sideOffset.dx() == 0 && sideOffset.dz() == 0)
+            return;
+
+        int x = center.getBlockX() + sideOffset.dx();
+        int z = center.getBlockZ() + sideOffset.dz();
+        int y = terrainResolver.getNearestRailSurfaceY(x, z, center.getBlockY());
+
+        PositionKey key = PositionKey.of(x, y, z);
+
+        if (centerPositions.contains(key))
+            return;
+
+        sideBlocks
+                .computeIfAbsent(key, ignored -> new RailSideBlock(key, DEFAULT_FACING))
+                .addFacing(sidePlacement.facing());
+    }
+
+    private Direction resolveSideBlockFacing(RailSideBlock sideBlock, Map<PositionKey, RailSideBlock> sideBlocks) {
+        PositionKey key = sideBlock.key();
+        boolean east = sideBlocks.containsKey(PositionKey.of(key.x() + 1, key.y(), key.z()));
+        boolean west = sideBlocks.containsKey(PositionKey.of(key.x() - 1, key.y(), key.z()));
+        boolean south = sideBlocks.containsKey(PositionKey.of(key.x(), key.y(), key.z() + 1));
+        boolean north = sideBlocks.containsKey(PositionKey.of(key.x(), key.y(), key.z() - 1));
+        int xConnections = (east ? 1 : 0) + (west ? 1 : 0);
+        int zConnections = (south ? 1 : 0) + (north ? 1 : 0);
+        Direction preferredFacing = sideBlock.getPreferredFacing();
+
+        if (xConnections > zConnections)
+            return resolveAxisFacing(preferredFacing, Direction.EAST, Direction.WEST, east, west);
+
+        if (zConnections > xConnections)
+            return resolveAxisFacing(preferredFacing, Direction.SOUTH, Direction.NORTH, south, north);
+
+        return preferredFacing;
+    }
+
+    private Direction resolveAxisFacing(
+            Direction preferredFacing,
+            Direction positiveFacing,
+            Direction negativeFacing,
+            boolean hasPositiveNeighbor,
+            boolean hasNegativeNeighbor
+    ) {
+        if (preferredFacing == positiveFacing && hasPositiveNeighbor || preferredFacing == negativeFacing && hasNegativeNeighbor)
+            return preferredFacing;
+
+        if (hasPositiveNeighbor && !hasNegativeNeighbor)
+            return positiveFacing;
+
+        if (hasNegativeNeighbor && !hasPositiveNeighbor)
+            return negativeFacing;
+
+        return preferredFacing == negativeFacing ? negativeFacing : positiveFacing;
+    }
+
+    private Set<PositionKey> getCenterPositions(List<List<Vector>> railCenterPaths) {
+        Set<PositionKey> centerPositions = new HashSet<>();
+
+        for (List<Vector> railCenterPath : railCenterPaths)
+            for (Vector center : railCenterPath)
+                centerPositions.add(PositionKey.from(center));
+
+        return centerPositions;
+    }
+
+    private RailStep getRailStep(List<Vector> path, int index, RailStep fallbackStep) {
+        RailStep previousStep = index > 0 ? getStep(path.get(index - 1), path.get(index)) : null;
+        RailStep nextStep = index < path.size() - 1 ? getStep(path.get(index), path.get(index + 1)) : null;
+
+        if (previousStep != null && nextStep != null) {
+            int dx = Integer.compare(previousStep.dx() + nextStep.dx(), 0);
+            int dz = Integer.compare(previousStep.dz() + nextStep.dz(), 0);
+
+            if (dx != 0 || dz != 0) return new RailStep(dx, dz);
+        }
+
+        if (nextStep != null) return nextStep;
+
+        if (previousStep != null) return previousStep;
+
+        return fallbackStep;
+    }
+
+    private RailStep getStep(Vector from, Vector to) {
+        int dx = Integer.compare(to.getBlockX() - from.getBlockX(), 0);
+        int dz = Integer.compare(to.getBlockZ() - from.getBlockZ(), 0);
+
+        if (dx == 0 && dz == 0) return null;
+
+        return new RailStep(dx, dz);
+    }
+
+    private BlockState createCenterBlockState(Vector position) {
+        return switch (railType) {
+            case STANDARD -> createStandardCenterBlockState(position);
+        };
+    }
+
+    private BlockState createStandardCenterBlockState(Vector position) {
+        int index = Math.floorMod(
+                position.getBlockX() * 31 + position.getBlockY() * 23 + position.getBlockZ() * 17,
+                CENTER_MATERIALS.length
+        );
+
+        return GeneratorUtils.getBlockState(CENTER_MATERIALS[index]);
+    }
+
+    private BlockState createAnvilBlockState(Direction direction) {
+        return GeneratorUtils.getBlockStateWithFacing(BlockTypes.ANVIL, direction);
+    }
+}

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailColumnKey.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailColumnKey.java
@@ -1,0 +1,8 @@
+package net.buildtheearth.buildteamtools.modules.generator.components.rail;
+
+record RailColumnKey(int x, int z) {
+
+    static RailColumnKey of(int x, int z) {
+        return new RailColumnKey(x, z);
+    }
+}

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailFlag.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailFlag.java
@@ -1,12 +1,18 @@
 package net.buildtheearth.buildteamtools.modules.generator.components.rail;
 
+import lombok.Getter;
 import net.buildtheearth.buildteamtools.modules.generator.model.Flag;
 import net.buildtheearth.buildteamtools.modules.generator.model.FlagType;
+import org.jspecify.annotations.Nullable;
 
 public enum RailFlag implements Flag {
-    LANE_COUNT("c", FlagType.INTEGER);
 
+    RAIL_TYPE("t", FlagType.RAIL_TYPE);
+
+    @Getter
     private final String flag;
+
+    @Getter
     private final FlagType flagType;
 
     RailFlag(String flag, FlagType flagType) {
@@ -14,20 +20,11 @@ public enum RailFlag implements Flag {
         this.flagType = flagType;
     }
 
-    @Override
-    public String getFlag() {
-        return flag;
-    }
-
-    @Override
-    public FlagType getFlagType() {
-        return flagType;
-    }
-
-    public static RailFlag byString(String flag) {
-        for (RailFlag railFlag : RailFlag.values())
+    public static @Nullable RailFlag byString(String flag) {
+        for (RailFlag railFlag : RailFlag.values()) {
             if (railFlag.getFlag().equalsIgnoreCase(flag))
                 return railFlag;
+        }
 
         return null;
     }

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailLanePathBuilder.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailLanePathBuilder.java
@@ -1,0 +1,211 @@
+package net.buildtheearth.buildteamtools.modules.generator.components.rail;
+
+import com.alpsbte.alpslib.utils.GeneratorUtils;
+import org.bukkit.util.Vector;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+final class RailLanePathBuilder {
+
+    private final List<Vector> controlPoints;
+    private final RailTerrainResolver terrainResolver;
+    private final int railLaneCount;
+    private final int railLaneSpacing;
+
+    RailLanePathBuilder(List<Vector> controlPoints, RailTerrainResolver terrainResolver, int railLaneCount, int railLaneSpacing) {
+        this.controlPoints = controlPoints;
+        this.terrainResolver = terrainResolver;
+        this.railLaneCount = railLaneCount;
+        this.railLaneSpacing = railLaneSpacing;
+    }
+
+    List<List<Vector>> createRailCenterPaths(List<Vector> path) {
+        if (railLaneCount <= 1)
+            return List.of(path);
+
+        List<List<Vector>> railCenterPaths = new ArrayList<>();
+        int sideLaneCount = (railLaneCount - 1) / 2;
+
+        for (int laneIndex = sideLaneCount; laneIndex >= 1; laneIndex--) {
+            List<Vector> leftLane = createShiftedRailLane(laneIndex * railLaneSpacing, 1);
+
+            if (leftLane.size() >= 2)
+                railCenterPaths.add(leftLane);
+        }
+
+        railCenterPaths.add(path);
+
+        for (int laneIndex = 1; laneIndex <= sideLaneCount; laneIndex++) {
+            List<Vector> rightLane = createShiftedRailLane(laneIndex * railLaneSpacing, -1);
+
+            if (rightLane.size() >= 2)
+                railCenterPaths.add(rightLane);
+        }
+
+        return railCenterPaths;
+    }
+
+    private List<Vector> createShiftedRailLane(int distance, int sideSign) {
+        List<List<Vector>> shiftedLines = GeneratorUtils.shiftPointsAll(controlPoints, distance);
+        List<Vector> candidatePoints = flattenShiftedLines(shiftedLines);
+
+        if (candidatePoints.isEmpty())
+            return Collections.emptyList();
+
+        List<Vector> shiftedControlPoints = createShiftedControlPoints(candidatePoints, distance, sideSign);
+
+        if (shiftedControlPoints.size() < 2)
+            return Collections.emptyList();
+
+        List<Vector> shiftedPath = createCenterPath(shiftedControlPoints);
+
+        if (shiftedPath.size() < 2)
+            return Collections.emptyList();
+
+        terrainResolver.adjustPathToTerrain(shiftedPath);
+        return shiftedPath;
+    }
+
+    private List<Vector> flattenShiftedLines(List<List<Vector>> shiftedLines) {
+        if (shiftedLines == null || shiftedLines.isEmpty())
+            return Collections.emptyList();
+
+        List<Vector> candidatePoints = new ArrayList<>();
+
+        for (List<Vector> shiftedLine : shiftedLines) {
+            if (shiftedLine == null || shiftedLine.isEmpty())
+                continue;
+
+            for (Vector point : shiftedLine) {
+                if (point != null)
+                    candidatePoints.add(point);
+            }
+        }
+
+        return candidatePoints;
+    }
+
+    private List<Vector> createShiftedControlPoints(List<Vector> candidatePoints, int distance, int sideSign) {
+        List<Vector> shiftedControlPoints = new ArrayList<>();
+
+        for (int index = 0; index < controlPoints.size(); index++) {
+            Vector basePoint = controlPoints.get(index);
+            Vector direction = getControlPointDirection(index);
+
+            if (direction.lengthSquared() == 0)
+                continue;
+
+            direction.normalize();
+
+            Vector normal = new Vector(-direction.getZ(), 0, direction.getX());
+
+            if (sideSign < 0)
+                normal.multiply(-1);
+
+            Vector shiftedPoint = getBestShiftedPoint(basePoint, normal, candidatePoints, distance);
+            addIfDifferentFromPrevious(shiftedControlPoints, shiftedPoint);
+        }
+
+        return shiftedControlPoints;
+    }
+
+    private Vector getControlPointDirection(int index) {
+        if (controlPoints.size() < 2)
+            return new Vector(0, 0, 0);
+
+        if (index == 0)
+            return getHorizontalDirection(controlPoints.get(0), controlPoints.get(1));
+
+        if (index == controlPoints.size() - 1)
+            return getHorizontalDirection(controlPoints.get(index - 1), controlPoints.get(index));
+
+        Vector previousDirection = getHorizontalDirection(controlPoints.get(index - 1), controlPoints.get(index));
+        Vector nextDirection = getHorizontalDirection(controlPoints.get(index), controlPoints.get(index + 1));
+        Vector combinedDirection = previousDirection.add(nextDirection);
+
+        if (combinedDirection.lengthSquared() != 0)
+            return combinedDirection;
+
+        if (nextDirection.lengthSquared() != 0)
+            return nextDirection;
+
+        return previousDirection;
+    }
+
+    private Vector getHorizontalDirection(Vector from, Vector to) {
+        return new Vector(
+                to.getBlockX() - from.getBlockX(),
+                0,
+                to.getBlockZ() - from.getBlockZ()
+        );
+    }
+
+    private Vector getBestShiftedPoint(Vector basePoint, Vector normal, List<Vector> candidatePoints, int distance) {
+        Vector idealPoint = getIdealShiftedPoint(basePoint, normal, distance);
+        Vector bestPoint = null;
+        double bestDistanceSquared = Double.MAX_VALUE;
+
+        for (Vector candidatePoint : candidatePoints) {
+            double signedOffset = getSignedOffset(basePoint, candidatePoint, normal);
+
+            if (signedOffset < 0.5D)
+                continue;
+
+            double distanceSquared = getHorizontalDistanceSquared(candidatePoint, idealPoint);
+
+            if (distanceSquared < bestDistanceSquared) {
+                bestDistanceSquared = distanceSquared;
+                bestPoint = candidatePoint;
+            }
+        }
+
+        double maxCandidateDistanceSquared = Math.max(16D, distance * distance * 2.25D);
+
+        if (bestPoint == null || bestDistanceSquared > maxCandidateDistanceSquared)
+            return idealPoint;
+
+        return new Vector(bestPoint.getBlockX(), basePoint.getBlockY(), bestPoint.getBlockZ());
+    }
+
+    private Vector getIdealShiftedPoint(Vector basePoint, Vector normal, int distance) {
+        return new Vector(
+                basePoint.getBlockX() + (int) Math.round(normal.getX() * distance),
+                basePoint.getBlockY(),
+                basePoint.getBlockZ() + (int) Math.round(normal.getZ() * distance)
+        );
+    }
+
+    private double getSignedOffset(Vector basePoint, Vector candidatePoint, Vector normal) {
+        double offsetX = candidatePoint.getX() - basePoint.getX();
+        double offsetZ = candidatePoint.getZ() - basePoint.getZ();
+
+        return offsetX * normal.getX() + offsetZ * normal.getZ();
+    }
+
+    private void addIfDifferentFromPrevious(List<Vector> points, Vector point) {
+        if (points.isEmpty()) {
+            points.add(point);
+            return;
+        }
+
+        Vector previousPoint = points.get(points.size() - 1);
+
+        if (previousPoint.getBlockX() == point.getBlockX() && previousPoint.getBlockZ() == point.getBlockZ())
+            return;
+
+        points.add(point);
+    }
+
+    private double getHorizontalDistanceSquared(Vector first, Vector second) {
+        double dx = first.getX() - second.getX();
+        double dz = first.getZ() - second.getZ();
+
+        return dx * dx + dz * dz;
+    }
+
+    private List<Vector> createCenterPath(List<Vector> points) {
+        return GeneratorUtils.removeOrthogonalCorners(GeneratorUtils.createShortestBlockPath(points));
+    }
+}

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailLimits.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailLimits.java
@@ -1,0 +1,50 @@
+package net.buildtheearth.buildteamtools.modules.generator.components.rail;
+
+import net.buildtheearth.buildteamtools.BuildTeamTools;
+import net.buildtheearth.buildteamtools.utils.io.ConfigPaths;
+import net.buildtheearth.buildteamtools.utils.io.ConfigUtil;
+import org.bukkit.configuration.file.FileConfiguration;
+
+record RailLimits(
+        int maxControlPoints,
+        int maxPathPoints,
+        int maxBlockPlacements,
+        long maxPreparedRegionVolume,
+        int maxPreparedRegionAxisLength,
+        int blockPlacementBatchSize
+) {
+
+    private static final int DEFAULT_MAX_CONTROL_POINTS = 1_000;
+    private static final int DEFAULT_MAX_PATH_POINTS = 24_000;
+    private static final int DEFAULT_MAX_BLOCK_PLACEMENTS = 150_000;
+    private static final long DEFAULT_MAX_PREPARED_REGION_VOLUME = 1_500_000L;
+    private static final int DEFAULT_MAX_PREPARED_REGION_AXIS_LENGTH = 1_024;
+    private static final int DEFAULT_BLOCK_PLACEMENT_BATCH_SIZE = 750;
+    private static final int MAX_CONTROL_POINTS = 2_000;
+    private static final int MAX_PATH_POINTS = 75_000;
+    private static final int MAX_BLOCK_PLACEMENTS = 300_000;
+    private static final long MAX_PREPARED_REGION_VOLUME = 6_000_000L;
+    private static final int MAX_PREPARED_REGION_AXIS_LENGTH = 2_048;
+    private static final int MAX_BLOCK_PLACEMENT_BATCH_SIZE = 2_000;
+
+    static RailLimits fromConfig() {
+        FileConfiguration config = BuildTeamTools.getInstance().getConfig(ConfigUtil.GENERATOR);
+
+        return new RailLimits(
+                getBoundedInt(config, ConfigPaths.Generator.Rail.MAX_CONTROL_POINTS, DEFAULT_MAX_CONTROL_POINTS, 2, MAX_CONTROL_POINTS),
+                getBoundedInt(config, ConfigPaths.Generator.Rail.MAX_PATH_POINTS, DEFAULT_MAX_PATH_POINTS, 2, MAX_PATH_POINTS),
+                getBoundedInt(config, ConfigPaths.Generator.Rail.MAX_BLOCK_PLACEMENTS, DEFAULT_MAX_BLOCK_PLACEMENTS, 1, MAX_BLOCK_PLACEMENTS),
+                getBoundedLong(config, ConfigPaths.Generator.Rail.MAX_PREPARED_REGION_VOLUME, DEFAULT_MAX_PREPARED_REGION_VOLUME, 1L, MAX_PREPARED_REGION_VOLUME),
+                getBoundedInt(config, ConfigPaths.Generator.Rail.MAX_PREPARED_REGION_AXIS_LENGTH, DEFAULT_MAX_PREPARED_REGION_AXIS_LENGTH, 1, MAX_PREPARED_REGION_AXIS_LENGTH),
+                getBoundedInt(config, ConfigPaths.Generator.Rail.BLOCK_PLACEMENT_BATCH_SIZE, DEFAULT_BLOCK_PLACEMENT_BATCH_SIZE, 1, MAX_BLOCK_PLACEMENT_BATCH_SIZE)
+        );
+    }
+
+    private static int getBoundedInt(FileConfiguration config, String path, int fallback, int minimum, int maximum) {
+        return Math.max(minimum, Math.min(maximum, config.getInt(path, fallback)));
+    }
+
+    private static long getBoundedLong(FileConfiguration config, String path, long fallback, long minimum, long maximum) {
+        return Math.max(minimum, Math.min(maximum, config.getLong(path, fallback)));
+    }
+}

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailPreparationProgress.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailPreparationProgress.java
@@ -1,0 +1,125 @@
+package net.buildtheearth.buildteamtools.modules.generator.components.rail;
+
+import com.alpsbte.alpslib.utils.ChatHelper;
+import net.buildtheearth.buildteamtools.BuildTeamTools;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitTask;
+
+final class RailPreparationProgress implements Runnable {
+
+    private final Player player;
+    private final long maxPercentage;
+    private final long updateIntervalTicks;
+    private volatile BukkitTask task;
+    private volatile long stageStartPercentage;
+    private volatile long stageEndPercentage;
+    private volatile long stageStartedAtMillis = System.currentTimeMillis();
+    private volatile long stageEstimatedDurationMillis = 1L;
+    private volatile long queuedPercentage = -1L;
+    private volatile long lastSentPercentage = -1L;
+
+    RailPreparationProgress(Player player, long maxPercentage, long updateIntervalTicks) {
+        this.player = player;
+        this.maxPercentage = maxPercentage;
+        this.updateIntervalTicks = updateIntervalTicks;
+    }
+
+    void start() {
+        if (!canContinue())
+            return;
+
+        if (task != null)
+            return;
+
+        task = Bukkit.getScheduler().runTaskTimerAsynchronously(
+                BuildTeamTools.getInstance(),
+                this,
+                0L,
+                updateIntervalTicks
+        );
+    }
+
+    void stop() {
+        BukkitTask currentTask = task;
+
+        if (currentTask == null)
+            return;
+
+        currentTask.cancel();
+        task = null;
+    }
+
+    void startStage(long startPercentage, long endPercentage, long estimatedDurationMillis) {
+        if (!canContinue())
+            return;
+
+        stageStartPercentage = clamp(startPercentage);
+        stageEndPercentage = clamp(endPercentage);
+        stageStartedAtMillis = System.currentTimeMillis();
+        stageEstimatedDurationMillis = Math.max(1L, estimatedDurationMillis);
+        update(stageStartPercentage);
+    }
+
+    void completeStage(long percentage) {
+        update(percentage);
+    }
+
+    void update(long percentage) {
+        if (!canContinue())
+            return;
+
+        long clampedPercentage = clamp(percentage);
+
+        if (clampedPercentage <= queuedPercentage)
+            return;
+
+        queuedPercentage = clampedPercentage;
+        if (clampedPercentage <= lastSentPercentage)
+            return;
+
+        lastSentPercentage = clampedPercentage;
+        player.sendActionBar(ChatHelper.getStandardComponent(false, "Generator Progress: %s", clampedPercentage + "%"));
+    }
+
+    long scale(int completed, int total, long startPercentage, long endPercentage) {
+        if (total <= 0)
+            return endPercentage;
+
+        double progress = Math.max(0D, Math.min(1D, (double) completed / (double) total));
+        return startPercentage + Math.round(progress * (endPercentage - startPercentage));
+    }
+
+    @Override
+    public void run() {
+        if (!canContinue()) {
+            stop();
+            return;
+        }
+
+        long currentStageStart = stageStartPercentage;
+        long currentStageEnd = stageEndPercentage;
+
+        if (currentStageEnd <= currentStageStart)
+            return;
+
+        long elapsedMillis = Math.max(0L, System.currentTimeMillis() - stageStartedAtMillis);
+        double progress = Math.min(0.98D, (double) elapsedMillis / (double) stageEstimatedDurationMillis);
+        long estimatedPercentage = currentStageStart + (long) Math.floor(progress * (currentStageEnd - currentStageStart));
+
+        if (estimatedPercentage >= currentStageEnd)
+            estimatedPercentage = currentStageEnd - 1L;
+
+        update(estimatedPercentage);
+    }
+
+    private long clamp(long percentage) {
+        return Math.max(0L, Math.min(maxPercentage, percentage));
+    }
+
+    private boolean canContinue() {
+        return BuildTeamTools.getInstance().isEnabled()
+                && player != null
+                && player.isOnline();
+    }
+}

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailScripts.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailScripts.java
@@ -1,130 +1,426 @@
 package net.buildtheearth.buildteamtools.modules.generator.components.rail;
 
+import com.alpsbte.alpslib.utils.ChatHelper;
 import com.alpsbte.alpslib.utils.GeneratorUtils;
+import com.sk89q.worldedit.world.block.BlockState;
+import net.buildtheearth.buildteamtools.BuildTeamTools;
 import net.buildtheearth.buildteamtools.modules.generator.model.GeneratorComponent;
 import net.buildtheearth.buildteamtools.modules.generator.model.Script;
+import net.buildtheearth.buildteamtools.modules.generator.model.Settings;
+import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class RailScripts extends Script {
 
-    public RailScripts(Player player, GeneratorComponent generatorComponent) {
-        super(player, generatorComponent);
+    private static final int SELECTION_PADDING = 4;
+    private static final int SELECTION_VERTICAL_PADDING = 12;
+    private static final int PREPARE_SELECTION_EXPANSION = 8;
 
-        throw new UnsupportedOperationException("RailScripts is currently broken.");
-        //getPlayer().chat("/clearhistory");
-        //Bukkit.getScheduler().runTaskAsynchronously(BuildTeamTools.getInstance(), this::railScript_v_1_3);
+    private static final long BLOCK_PLACEMENT_START_PERCENTAGE = 95L;
+    private static final long PROGRESS_UPDATE_INTERVAL_TICKS = 4L;
+
+    private static final long CONTROL_POINTS_PROGRESS = 3L;
+    private static final long PATH_PROGRESS = 10L;
+    private static final long SAFETY_CHECK_PROGRESS = 18L;
+    private static final long TERRAIN_PREPARE_PROGRESS = 68L;
+    private static final long TERRAIN_ADJUST_PROGRESS = 78L;
+    private static final long RAIL_BLOCK_BUILD_PROGRESS = 92L;
+    private static final long QUEUE_OPERATIONS_PROGRESS = BLOCK_PLACEMENT_START_PERCENTAGE;
+
+    private static final long CONTROL_POINTS_ESTIMATED_MILLIS = 500L;
+    private static final long PATH_ESTIMATED_MILLIS = 750L;
+    private static final long SAFETY_CHECK_ESTIMATED_MILLIS = 500L;
+    private static final long TERRAIN_PREPARE_ESTIMATED_MILLIS = 4_500L;
+    private static final long TERRAIN_ADJUST_ESTIMATED_MILLIS = 1_200L;
+    private static final long RAIL_BLOCK_BUILD_ESTIMATED_MILLIS = 1_800L;
+    private static final long QUEUE_OPERATIONS_ESTIMATED_MILLIS = 300L;
+
+    private static final int DEFAULT_RAIL_LANE_COUNT = 1;
+    private static final int DEFAULT_RAIL_LANE_SPACING = 5;
+
+    private Block[][][] blocks;
+    private List<Vector> controlPoints = new ArrayList<>();
+    private List<Vector> centerPath = new ArrayList<>();
+    private RailTerrainResolver terrainResolver;
+    private RailType railType = RailType.STANDARD;
+    private final RailLimits limits;
+    private final RailPreparationProgress preparationProgress;
+    private final Runnable preparationFinishedCallback;
+    private int railReferenceY;
+
+    public RailScripts(Player player, GeneratorComponent generatorComponent, Runnable preparationFinishedCallback) {
+        super(player, generatorComponent);
+        this.limits = RailLimits.fromConfig();
+        this.preparationProgress = new RailPreparationProgress(player, BLOCK_PLACEMENT_START_PERCENTAGE, PROGRESS_UPDATE_INTERVAL_TICKS);
+        this.preparationFinishedCallback = preparationFinishedCallback;
+
+        preparationProgress.start();
+        preparationProgress.startStage(0L, CONTROL_POINTS_PROGRESS, CONTROL_POINTS_ESTIMATED_MILLIS);
+        sendRailInfo("Rail Generator is validating your selection...");
+
+        Bukkit.getScheduler().runTaskAsynchronously(BuildTeamTools.getInstance(), () -> {
+            boolean queuedGeneration = false;
+
+            try {
+                if (!canContinue()) return;
+                if (!prepareSession()) return;
+
+                queuedGeneration = queueRailGeneration();
+            } catch (Exception exception) {
+                getGeneratorComponent().sendError(getPlayer());
+                ChatHelper.logError("Rail Generator failed while preparing or generating.", exception);
+            } finally {
+                if (!queuedGeneration) {
+                    runOnMainThread(() -> {
+                        preparationProgress.stop();
+                        runPreparationFinishedCallbackSafely();
+                    });
+                }
+            }
+        });
     }
 
-    public void railScript_v_1_3() {
-        List<String> commands = new ArrayList<>();
-        //HashMap<Flag, String > flags = rail.getPlayerSettings().get(p.getUniqueId()).getValues();
+    private boolean prepareSession() {
+        if (!canContinue()) return false;
 
-        int xPos = getPlayer().getLocation().getBlockX();
-        int zPos = getPlayer().getLocation().getBlockZ();
+        controlPoints = getControlPoints();
+        railReferenceY = getRailReferenceY(controlPoints);
+        preparationProgress.completeStage(CONTROL_POINTS_PROGRESS);
 
-        int operations = 0;
+        if (!hasValidControlPoints()) return false;
 
-        int railWidth = 5;
+        preparationProgress.startStage(CONTROL_POINTS_PROGRESS, PATH_PROGRESS, PATH_ESTIMATED_MILLIS);
+        List<Vector> railSelectionPoints = createRailSelectionPoints(controlPoints);
+        centerPath = createCenterPath(controlPoints);
+        preparationProgress.completeStage(PATH_PROGRESS);
 
+        if (!hasValidCenterPath()) return false;
 
-        // TODO START TEMP
+        preparationProgress.startStage(PATH_PROGRESS, SAFETY_CHECK_PROGRESS, SAFETY_CHECK_ESTIMATED_MILLIS);
+        if (!hasSafeEstimatedBlockCount(centerPath)) return false;
 
-        Block[][][] regionBlocks = GeneratorUtils.analyzeRegion(getPlayer(), getPlayer().getWorld());
-        List<Vector> points = GeneratorUtils.getSelectionPointsFromRegion(getRegion());
-        createCuboidSelection(points.get(0), points.get(1));
-        createCommand("//set redstone_block");
-        createBreakPoint();
-        createCommand("//set gold_block");
+        int selectionMinY = getSelectionMinY(controlPoints);
+        int selectionMaxY = getSelectionMaxY(controlPoints);
 
-        finish(regionBlocks, points);
+        if (!hasSafePreparedSelection(railSelectionPoints, selectionMinY, selectionMaxY)) return false;
 
+        preparationProgress.completeStage(SAFETY_CHECK_PROGRESS);
+        sendRailInfo("Rail Generator is preparing terrain data...");
+        preparationProgress.startStage(SAFETY_CHECK_PROGRESS, TERRAIN_PREPARE_PROGRESS, TERRAIN_PREPARE_ESTIMATED_MILLIS);
 
-        // TODO END TEMP
+        GeneratorUtils.createPolySelection(
+                getPlayer(),
+                railSelectionPoints,
+                selectionMinY,
+                selectionMaxY
+        );
 
-        /*
-        // Get the points of the region
-        List<Vector> points = GeneratorUtils.getSelectionPointsFromRegion(getRegion());
-        points = GeneratorUtils.populatePoints(points, 5);
+        blocks = GeneratorUtils.prepareScriptSession(
+                localSession,
+                actor,
+                getPlayer(),
+                weWorld,
+                PREPARE_SELECTION_EXPANSION,
+                true,
+                false,
+                false
+        );
+        terrainResolver = new RailTerrainResolver(blocks);
+        preparationProgress.completeStage(TERRAIN_PREPARE_PROGRESS);
 
-        // ----------- PREPARATION 01 ----------
-        // Replace all unnecessary blocks with air
+        if (!canContinue()) return false;
 
-        List<Vector> polyRegionLine = new ArrayList<>(points);
-        polyRegionLine = GeneratorUtils.extendPolyLine(polyRegionLine);
-        List<Vector> polyRegionPoints = GeneratorUtils.shiftPoints(polyRegionLine, railWidth + 2, true);
+        preparationProgress.startStage(TERRAIN_PREPARE_PROGRESS, TERRAIN_ADJUST_PROGRESS, TERRAIN_ADJUST_ESTIMATED_MILLIS);
+        snapMissingControlPointHeightsToTerrain(controlPoints);
+        centerPath = createCenterPath(controlPoints);
+        adjustCenterPathToTerrain();
+        railType = getRailType();
+        preparationProgress.completeStage(TERRAIN_ADJUST_PROGRESS);
 
-        // Create a region from the points
-        GeneratorUtils.createPolySelection(getPlayer(), polyRegionPoints, null);
+        return true;
+    }
 
-        getPlayer().chat("//expand 30 up");
-        getPlayer().chat("//expand 10 down");
+    private boolean queueRailGeneration() {
+        if (!canContinue()) return false;
 
-        // Remove non-solid blocks
-        getPlayer().chat("//gmask !#solid");
-        getPlayer().chat("//replace 0");
-        operations++;
+        if (!hasValidCenterPath())
+            return false;
 
-        // Remove all trees and pumpkins
-        getPlayer().chat("//gmask");
-        getPlayer().chat("//replace leaves,log,pumpkin 0");
-        operations++;
+        preparationProgress.startStage(TERRAIN_ADJUST_PROGRESS, RAIL_BLOCK_BUILD_PROGRESS, RAIL_BLOCK_BUILD_ESTIMATED_MILLIS);
+        Map<PositionKey, BlockState> railBlocks = buildRailBlocks(centerPath);
+        preparationProgress.completeStage(RAIL_BLOCK_BUILD_PROGRESS);
 
-        getPlayer().chat("//gmask");
-
-
-        Block[][][] regionBlocks = GeneratorUtils.analyzeRegion(getPlayer(), getPlayer().getWorld());
-        GeneratorUtils.adjustHeight(points, regionBlocks);
-
-
-        // ----------- RAILWAY ----------
-
-        // Draw the railway curve
-
-        GeneratorUtils.createConvexSelection(commands, points);
-        commands.add("//gmask !solid");
-        commands.add("//curve 42");
-        operations++;
-        commands.add("//gmask");
-
-
-        // Create the railway
-        GeneratorUtils.createPolySelection(commands, polyRegionPoints);
-
-        commands.add("//replace \"0 !>42 =queryRel(0,-1,-1,42,-1)||queryRel(0,-1,1,42,-1)\" 145:1");
-        operations++;
-        commands.add("//replace \"0 !>42 =queryRel(-1,-1,0,42,-1)||queryRel(1,-1,0,42,-1)\" 145:0");
-        operations++;
-
-        commands.add("//gmask =(sqrt((x-(" + xPos + "))^2+(z-(" + zPos + "))^2)%3)-2");
-        commands.add("//replace \"0 =queryRel(0,0,1,145,-1)||queryRel(0,0,-1,145,-1)||queryRel(1,0,0,145,-1)||queryRel(-1,0,0,
-        145,-1)\" 44:0");
-        operations++;
-        commands.add("//replace \"!145 !0 <145\" 43:0");
-        operations++;
-        commands.add("//gmask");
-        commands.add("//replace 42 2");
-        operations++;
-
-        commands.add("//gmask");
-
-        // Depending on the selection type, the selection needs to be restored correctly
-        if(getRegion() instanceof Polygonal2DRegion || getRegion() instanceof ConvexPolyhedralRegion)
-            GeneratorUtils.createConvexSelection(commands, points);
-        else if(getRegion() instanceof CuboidRegion){
-            CuboidRegion cuboidRegion = (CuboidRegion) getRegion();
-            Vector pos1 = new Vector(cuboidRegion.getPos1().getX(), cuboidRegion.getPos1().getY(), cuboidRegion.getPos1().getZ());
-            Vector pos2 = new Vector(cuboidRegion.getPos2().getX(), cuboidRegion.getPos2().getY(), cuboidRegion.getPos2().getZ());
-            GeneratorUtils.createCuboidSelection(commands, pos1, pos2);
+        if (railBlocks.size() > limits.maxBlockPlacements()) {
+            sendRailError("Rail Generator would place " + railBlocks.size() + " blocks. The limit is "
+                    + limits.maxBlockPlacements() + ". Split the rail into smaller selections.");
+            return false;
         }
 
-        GeneratorModule.getInstance().getGeneratorCommands().add(new Command(getPlayer(), getGeneratorComponent(), commands,
-        operations, regionBlocks));
-        GeneratorModule.getInstance().getPlayerHistory(getPlayer()).addHistoryEntry(new History.HistoryEntry(GeneratorType
-        .RAILWAY, operations));*/
+        sendRailInfo("Rail Generator queued " + railBlocks.size() + " block changes over "
+                + centerPath.size() + " path points.");
+
+        preparationProgress.startStage(RAIL_BLOCK_BUILD_PROGRESS, QUEUE_OPERATIONS_PROGRESS, QUEUE_OPERATIONS_ESTIMATED_MILLIS);
+        queueRailBlockPlacements(railBlocks);
+        preparationProgress.completeStage(QUEUE_OPERATIONS_PROGRESS);
+
+        setProgressRange(BLOCK_PLACEMENT_START_PERCENTAGE, 100L);
+
+        preparationProgress.stop();
+        finishOnMainThread();
+        return true;
     }
+
+    private void queueRailBlockPlacements(Map<PositionKey, BlockState> railBlocks) {
+        List<Vector> positions = new ArrayList<>(limits.blockPlacementBatchSize());
+        List<BlockState> blockStates = new ArrayList<>(limits.blockPlacementBatchSize());
+
+        for (Map.Entry<PositionKey, BlockState> entry : railBlocks.entrySet()) {
+            positions.add(entry.getKey().toVector());
+            blockStates.add(entry.getValue());
+
+            if (positions.size() == limits.blockPlacementBatchSize()) {
+                setBlockStatesAtPositions(new ArrayList<>(positions), new ArrayList<>(blockStates));
+                positions.clear();
+                blockStates.clear();
+            }
+        }
+
+        if (!positions.isEmpty())
+            setBlockStatesAtPositions(positions, blockStates);
+    }
+
+    private void finishOnMainThread() {
+        runOnMainThread(() -> {
+            try {
+                finish(blocks, controlPoints);
+            } catch (Exception exception) {
+                getGeneratorComponent().sendError(getPlayer());
+                ChatHelper.logError("Rail Generator failed while finishing.", exception);
+            } finally {
+                runPreparationFinishedCallbackSafely();
+            }
+        });
+    }
+
+    private void runPreparationFinishedCallbackSafely() {
+        try {
+            preparationFinishedCallback.run();
+        } catch (Exception exception) {
+            ChatHelper.logError("Rail Generator preparation callback failed.", exception);
+        }
+    }
+
+    private boolean hasValidControlPoints() {
+        if (controlPoints.size() < 2) {
+            sendRailError("Rail Generator needs at least two points.");
+            return false;
+        }
+
+        if (controlPoints.size() > limits.maxControlPoints()) {
+            sendRailError("Rail Generator has too many points. Please use fewer points.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean hasValidCenterPath() {
+        if (centerPath.size() < 2) {
+            sendRailError("Rail Generator could not create a valid rail path. Select at least two different blocks.");
+            return false;
+        }
+
+        if (centerPath.size() > limits.maxPathPoints()) {
+            sendRailError("Rail Generator path has " + centerPath.size() + " points. The limit is "
+                    + limits.maxPathPoints() + ". Split the rail into smaller selections.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean hasSafeEstimatedBlockCount(List<Vector> path) {
+        long estimatedBlocks = (long) path.size() * getRailLaneCount() * 5L;
+
+        if (estimatedBlocks <= limits.maxBlockPlacements())
+            return true;
+
+        sendRailError("Rail Generator would likely place too many blocks. Split the rail into smaller selections.");
+        return false;
+    }
+
+    private boolean hasSafePreparedSelection(List<Vector> selectionPoints, int minY, int maxY) {
+        if (selectionPoints.size() < 2) {
+            sendRailError("Rail Generator could not create a safe preparation selection.");
+            return false;
+        }
+
+        int minX = Integer.MAX_VALUE;
+        int minZ = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE;
+        int maxZ = Integer.MIN_VALUE;
+
+        for (Vector point : selectionPoints) {
+            minX = Math.min(minX, point.getBlockX());
+            minZ = Math.min(minZ, point.getBlockZ());
+            maxX = Math.max(maxX, point.getBlockX());
+            maxZ = Math.max(maxZ, point.getBlockZ());
+        }
+
+        long width = (long) maxX - minX + 1L;
+        long height = (long) maxY - minY + 1L + PREPARE_SELECTION_EXPANSION * 2L;
+        long length = (long) maxZ - minZ + 1L;
+        long volume = width * height * length;
+
+        if (width > limits.maxPreparedRegionAxisLength() || length > limits.maxPreparedRegionAxisLength()) {
+            sendRailError("Rail Generator selection is too wide to prepare safely. Split the rail into smaller selections.");
+            return false;
+        }
+
+        if (volume > limits.maxPreparedRegionVolume()) {
+            sendRailError("Rail Generator selection would prepare " + volume + " blocks. The limit is "
+                    + limits.maxPreparedRegionVolume() + ". Split the rail into smaller selections.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private void sendRailInfo(String message) {
+        if (!canContinue()) return;
+
+        getPlayer().sendMessage(ChatHelper.getStandardComponent(true, message));
+    }
+
+    private void sendRailError(String message) {
+        if (!canContinue()) return;
+
+        getPlayer().sendMessage(ChatHelper.PREFIX_COMPONENT.append(ChatHelper.getErrorComponent(message)));
+    }
+
+    private void runOnMainThread(Runnable runnable) {
+        if (!BuildTeamTools.getInstance().isEnabled())
+            return;
+
+        if (Bukkit.isPrimaryThread()) {
+            runnable.run();
+            return;
+        }
+
+        Bukkit.getScheduler().runTask(BuildTeamTools.getInstance(), runnable);
+    }
+
+    private boolean canContinue() {
+        return BuildTeamTools.getInstance().isEnabled()
+                && getPlayer() != null
+                && getPlayer().isOnline();
+    }
+
+    private List<Vector> getControlPoints() {
+        List<Vector> selectionPoints = GeneratorUtils.getSelectionPointsFromRegion(getRegion());
+
+        if (selectionPoints == null) return Collections.emptyList();
+
+        return GeneratorUtils.copyToBlockVectors(selectionPoints);
+    }
+
+    private List<Vector> createRailSelectionPoints(List<Vector> points) {
+        List<Vector> selectionLine = new ArrayList<>(points);
+
+        if (selectionLine.size() >= 2)
+            selectionLine = GeneratorUtils.extendPolyLine(selectionLine);
+
+        List<Vector> shiftedPoints = GeneratorUtils.shiftPoints(selectionLine, getSelectionPadding(), true);
+
+        if (shiftedPoints == null || shiftedPoints.size() < 3)
+            return GeneratorUtils.createBoundsSelectionPoints(points, getSelectionPadding());
+
+        return shiftedPoints;
+    }
+
+    private int getSelectionPadding() {
+        int sideLaneCount = (getRailLaneCount() - 1) / 2;
+        return SELECTION_PADDING + (getRailLaneSpacing() * sideLaneCount) + 2;
+    }
+
+    private List<Vector> createCenterPath(List<Vector> points) {
+        return GeneratorUtils.removeOrthogonalCorners(GeneratorUtils.createShortestBlockPath(points));
+    }
+
+    private Map<PositionKey, BlockState> buildRailBlocks(List<Vector> path) {
+        return new RailBlockBuilder(
+                controlPoints,
+                terrainResolver,
+                railType,
+                preparationProgress,
+                getRailLaneCount(),
+                getRailLaneSpacing(),
+                TERRAIN_ADJUST_PROGRESS,
+                RAIL_BLOCK_BUILD_PROGRESS
+        ).build(path);
+    }
+
+    private int getRailLaneCount() {
+        return DEFAULT_RAIL_LANE_COUNT;
+    }
+
+    private int getRailLaneSpacing() {
+        return DEFAULT_RAIL_LANE_SPACING;
+    }
+
+    private void snapMissingControlPointHeightsToTerrain(List<Vector> points) {
+        if (terrainResolver == null)
+            return;
+
+        terrainResolver.snapMissingHeightsToTerrain(points, railReferenceY);
+    }
+
+    private void adjustCenterPathToTerrain() {
+        if (terrainResolver == null || centerPath.isEmpty()) return;
+
+        for (int index = 0; index < centerPath.size(); index++) {
+            Vector point = centerPath.get(index);
+            point.setY(terrainResolver.getNearestRailSurfaceY(point.getBlockX(), point.getBlockZ(), point.getBlockY()));
+            preparationProgress.update(preparationProgress.scale(index + 1, centerPath.size(), TERRAIN_PREPARE_PROGRESS, TERRAIN_ADJUST_PROGRESS));
+        }
+    }
+
+    private int getRailReferenceY(List<Vector> points) {
+        if (points.isEmpty())
+            return getPlayer().getWorld().getMinHeight();
+
+        if (!RailTerrainResolver.hasAnyMissingHeights(points))
+            return points.getFirst().getBlockY();
+
+        int referenceY = getRegion() != null ? getRegion().getMinimumY() : GeneratorUtils.getMinHeight(points);
+        return Math.min(getPlayer().getWorld().getMaxHeight() - 1, referenceY + 1);
+    }
+
+    private int getSelectionMinY(List<Vector> points) {
+        int minY = getRegion() != null ? getRegion().getMinimumY() : GeneratorUtils.getMinHeight(points);
+        return Math.max(getPlayer().getWorld().getMinHeight(), minY - SELECTION_VERTICAL_PADDING);
+    }
+
+    private int getSelectionMaxY(List<Vector> points) {
+        int maxY = getRegion() != null ? getRegion().getMaximumY() : GeneratorUtils.getMaxHeight(points);
+        return Math.min(getPlayer().getWorld().getMaxHeight() - 1, maxY + SELECTION_VERTICAL_PADDING);
+    }
+
+    private RailType getRailType() {
+        Settings settings = getGeneratorComponent().getPlayerSettings().get(getPlayer().getUniqueId());
+
+        if (!(settings instanceof RailSettings railSettings))
+            return RailType.STANDARD;
+
+        Object value = railSettings.getValues().get(RailFlag.RAIL_TYPE);
+        return value instanceof RailType selectedRailType ? selectedRailType : RailType.STANDARD;
+    }
+
 }

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailSettings.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailSettings.java
@@ -9,9 +9,8 @@ public class RailSettings extends Settings {
         super(player);
     }
 
+    @Override
     public void setDefaultValues() {
-
-        // Lane Count (Default: Fixed Value)
-        setValue(RailFlag.LANE_COUNT, 1);
+        setValue(RailFlag.RAIL_TYPE, RailType.STANDARD);
     }
 }

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailSideBlock.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailSideBlock.java
@@ -1,0 +1,40 @@
+package net.buildtheearth.buildteamtools.modules.generator.components.rail;
+
+import com.sk89q.worldedit.util.Direction;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+final class RailSideBlock {
+
+    private final PositionKey key;
+    private final Direction defaultFacing;
+    private final Map<Direction, Integer> facingScores = new LinkedHashMap<>();
+
+    RailSideBlock(PositionKey key, Direction defaultFacing) {
+        this.key = key;
+        this.defaultFacing = defaultFacing;
+    }
+
+    PositionKey key() {
+        return key;
+    }
+
+    void addFacing(Direction facing) {
+        facingScores.merge(facing, 1, Integer::sum);
+    }
+
+    Direction getPreferredFacing() {
+        Direction preferredFacing = defaultFacing;
+        int preferredScore = -1;
+
+        for (Map.Entry<Direction, Integer> entry : facingScores.entrySet()) {
+            if (entry.getValue() > preferredScore) {
+                preferredFacing = entry.getKey();
+                preferredScore = entry.getValue();
+            }
+        }
+
+        return preferredFacing;
+    }
+}

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailSidePlacement.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailSidePlacement.java
@@ -1,0 +1,6 @@
+package net.buildtheearth.buildteamtools.modules.generator.components.rail;
+
+import com.sk89q.worldedit.util.Direction;
+
+record RailSidePlacement(RailStep offset, Direction facing) {
+}

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailStep.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailStep.java
@@ -1,0 +1,4 @@
+package net.buildtheearth.buildteamtools.modules.generator.components.rail;
+
+record RailStep(int dx, int dz) {
+}

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailTerrainResolver.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailTerrainResolver.java
@@ -1,0 +1,130 @@
+package net.buildtheearth.buildteamtools.modules.generator.components.rail;
+
+import net.buildtheearth.buildteamtools.utils.MenuItems;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.util.Vector;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+final class RailTerrainResolver {
+
+    private static final int SURFACE_Y_OFFSET = 1;
+
+    private final Map<PositionKey, Block> blocksByPosition = new HashMap<>();
+    private final Map<RailColumnKey, List<Block>> blocksByColumn = new HashMap<>();
+    private final Map<PositionKey, Integer> railYCache = new HashMap<>();
+
+    RailTerrainResolver(Block[][][] blocks) {
+        indexPreparedBlocks(blocks);
+    }
+
+    void snapMissingHeightsToTerrain(List<Vector> points, int referenceY) {
+        if (!hasAnyMissingHeights(points))
+            return;
+
+        for (Vector point : points)
+            if (point.getBlockY() == 0)
+                point.setY(getNearestRailSurfaceY(point.getBlockX(), point.getBlockZ(), referenceY));
+    }
+
+    void adjustPathToTerrain(List<Vector> path) {
+        for (Vector point : path)
+            point.setY(getNearestRailSurfaceY(point.getBlockX(), point.getBlockZ(), point.getBlockY()));
+    }
+
+    int getNearestRailSurfaceY(int x, int z, int fallbackY) {
+        PositionKey cacheKey = PositionKey.of(x, fallbackY, z);
+        return railYCache.computeIfAbsent(cacheKey, ignored -> findNearestRailSurfaceY(x, z, fallbackY));
+    }
+
+    static boolean hasAnyMissingHeights(List<Vector> points) {
+        for (Vector point : points)
+            if (point.getBlockY() == 0) return true;
+
+        return false;
+    }
+
+    private void indexPreparedBlocks(Block[][][] blocks) {
+        if (blocks == null)
+            return;
+
+        for (Block[][] block2D : blocks) {
+            for (Block[] block1D : block2D) {
+                for (Block block : block1D) {
+                    if (block == null)
+                        continue;
+
+                    blocksByPosition.put(PositionKey.of(block.getX(), block.getY(), block.getZ()), block);
+                    blocksByColumn
+                            .computeIfAbsent(RailColumnKey.of(block.getX(), block.getZ()), ignored -> new ArrayList<>())
+                            .add(block);
+                }
+            }
+        }
+
+        for (List<Block> columnBlocks : blocksByColumn.values())
+            columnBlocks.sort(Comparator.comparingInt(Block::getY));
+    }
+
+    private int findNearestRailSurfaceY(int x, int z, int fallbackY) {
+        List<Block> columnBlocks = blocksByColumn.get(RailColumnKey.of(x, z));
+
+        if (columnBlocks == null || columnBlocks.isEmpty())
+            return fallbackY;
+
+        int nearestRailY = fallbackY;
+        int nearestDistance = Integer.MAX_VALUE;
+        int highestRailY = Integer.MIN_VALUE;
+
+        for (Block block : columnBlocks) {
+            if (!isRailGroundBlock(block))
+                continue;
+
+            int railY = block.getY() + SURFACE_Y_OFFSET;
+            int distance = Math.abs(railY - fallbackY);
+            highestRailY = Math.max(highestRailY, railY);
+
+            if (distance < nearestDistance || distance == nearestDistance && railY <= fallbackY) {
+                nearestRailY = railY;
+                nearestDistance = distance;
+            }
+        }
+
+        if (nearestDistance != Integer.MAX_VALUE)
+            return nearestRailY;
+
+        return highestRailY == Integer.MIN_VALUE ? fallbackY : highestRailY;
+    }
+
+    private boolean isRailGroundBlock(Block block) {
+        if (block.isLiquid() || !block.getType().isSolid())
+            return false;
+
+        for (Material ignoredMaterial : MenuItems.getIgnoredMaterials())
+            if (block.getType() == ignoredMaterial)
+                return false;
+
+        return isRailPlacementOpen(block.getX(), block.getY() + SURFACE_Y_OFFSET, block.getZ());
+    }
+
+    private boolean isRailPlacementOpen(int x, int y, int z) {
+        Block block = blocksByPosition.get(PositionKey.of(x, y, z));
+
+        if (block == null)
+            return true;
+
+        if (block.isLiquid() || block.getType().isAir() || !block.getType().isSolid())
+            return true;
+
+        for (Material ignoredMaterial : MenuItems.getIgnoredMaterials())
+            if (block.getType() == ignoredMaterial)
+                return true;
+
+        return false;
+    }
+}

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailType.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/RailType.java
@@ -1,0 +1,32 @@
+package net.buildtheearth.buildteamtools.modules.generator.components.rail;
+
+import com.cryptomorin.xseries.XMaterial;
+import lombok.Getter;
+import org.jspecify.annotations.Nullable;
+
+public enum RailType {
+
+    STANDARD("standard", "Standard", XMaterial.RAIL);
+
+    @Getter
+    private final String identifier;
+    @Getter
+    private final String displayName;
+    @Getter
+    private final XMaterial icon;
+
+    RailType(String identifier, String displayName, XMaterial icon) {
+        this.identifier = identifier;
+        this.displayName = displayName;
+        this.icon = icon;
+    }
+
+    public static @Nullable RailType byString(String value) {
+        for (RailType railType : RailType.values()) {
+            if (railType.getIdentifier().equalsIgnoreCase(value) || railType.name().equalsIgnoreCase(value))
+                return railType;
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/menu/RailTypeMenu.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/components/rail/menu/RailTypeMenu.java
@@ -1,0 +1,61 @@
+package net.buildtheearth.buildteamtools.modules.generator.components.rail.menu;
+
+import com.alpsbte.alpslib.utils.item.Item;
+import net.buildtheearth.buildteamtools.modules.generator.GeneratorModule;
+import net.buildtheearth.buildteamtools.modules.generator.components.rail.RailFlag;
+import net.buildtheearth.buildteamtools.modules.generator.components.rail.RailSettings;
+import net.buildtheearth.buildteamtools.modules.generator.components.rail.RailType;
+import net.buildtheearth.buildteamtools.modules.generator.menu.GeneratorMenu;
+import net.buildtheearth.buildteamtools.modules.generator.model.Settings;
+import net.buildtheearth.buildteamtools.utils.menus.NameListMenu;
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.jspecify.annotations.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class RailTypeMenu extends NameListMenu {
+
+    public static final String RAIL_TYPE_INV_NAME = "Choose a Rail Type";
+
+    public RailTypeMenu(Player player, boolean autoLoad) {
+        super(player, RAIL_TYPE_INV_NAME, getRailTypes(), new GeneratorMenu(player, false), autoLoad);
+    }
+
+    private static @NonNull List<MutablePair<ItemStack, String>> getRailTypes() {
+        List<MutablePair<ItemStack, String>> railTypes = new ArrayList<>();
+
+        for (RailType railType : RailType.values()) {
+            railTypes.add(new MutablePair<>(
+                    Item.create(Objects.requireNonNull(railType.getIcon().get()), railType.getDisplayName()),
+                    railType.getIdentifier()
+            ));
+        }
+
+        return railTypes;
+    }
+
+    @Override
+    protected void setItemClickEventsAsync() {
+        super.setItemClickEventsAsync();
+
+        if (canProceed())
+            getMenu().getSlot(NEXT_ITEM_SLOT).setClickHandler((clickPlayer, clickInformation) -> {
+                Settings settings = GeneratorModule.getInstance().getRail().getPlayerSettings().get(clickPlayer.getUniqueId());
+
+                if (!(settings instanceof RailSettings railSettings))
+                    return;
+
+                railSettings.setValue(RailFlag.RAIL_TYPE, selectedNames.getFirst());
+
+                clickPlayer.closeInventory();
+                clickPlayer.playSound(clickPlayer.getLocation(), Sound.UI_BUTTON_CLICK, 1.0F, 1.0F);
+
+                GeneratorModule.getInstance().getRail().generate(clickPlayer);
+            });
+    }
+}

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/listeners/GeneratorListener.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/listeners/GeneratorListener.java
@@ -11,7 +11,52 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 
+import java.util.Map;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
 public class GeneratorListener implements Listener {
+
+    private static final Map<UUID, Queue<String>> INTERNAL_GENERATOR_COMMANDS = new ConcurrentHashMap<>();
+
+    public static void queueInternalGeneratorCommand(Player player, String command) {
+        INTERNAL_GENERATOR_COMMANDS
+                .computeIfAbsent(player.getUniqueId(), ignored -> new ConcurrentLinkedQueue<>())
+                .add(command);
+    }
+
+    public static void removeInternalGeneratorCommand(Player player, String command) {
+        Queue<String> commands = INTERNAL_GENERATOR_COMMANDS.get(player.getUniqueId());
+
+        if (commands == null)
+            return;
+
+        commands.remove(command);
+
+        if (commands.isEmpty())
+            INTERNAL_GENERATOR_COMMANDS.remove(player.getUniqueId(), commands);
+    }
+
+    private static boolean consumeInternalGeneratorCommand(Player player, String command) {
+        Queue<String> commands = INTERNAL_GENERATOR_COMMANDS.get(player.getUniqueId());
+
+        if (commands == null)
+            return false;
+
+        String queuedCommand = commands.peek();
+
+        if (!command.equals(queuedCommand))
+            return false;
+
+        commands.poll();
+
+        if (commands.isEmpty())
+            INTERNAL_GENERATOR_COMMANDS.remove(player.getUniqueId(), commands);
+
+        return true;
+    }
 
     @EventHandler
     public void onCommand(PlayerCommandPreprocessEvent e) {
@@ -19,7 +64,11 @@ public class GeneratorListener implements Listener {
 
         if (!GeneratorModule.getInstance().isGenerating(p))
             return;
+
         if (!e.getMessage().startsWith("//"))
+            return;
+
+        if (consumeInternalGeneratorCommand(p, e.getMessage()))
             return;
 
         e.setCancelled(true);
@@ -33,8 +82,10 @@ public class GeneratorListener implements Listener {
 
         if (!GeneratorModule.getInstance().isGenerating(p))
             return;
+
         if (e.getItem() == null)
             return;
+
         if (e.getItem().getType() != Material.WOODEN_AXE)
             return;
 

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/menu/GeneratorMenu.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/menu/GeneratorMenu.java
@@ -1,6 +1,7 @@
 package net.buildtheearth.buildteamtools.modules.generator.menu;
 
 import com.alpsbte.alpslib.utils.item.Item;
+import com.alpsbte.alpslib.utils.ChatHelper;
 import com.cryptomorin.xseries.XMaterial;
 import net.buildtheearth.buildteamtools.modules.common.CommonModule;
 import net.buildtheearth.buildteamtools.modules.generator.GeneratorModule;
@@ -8,6 +9,9 @@ import net.buildtheearth.buildteamtools.modules.generator.components.house.House
 import net.buildtheearth.buildteamtools.modules.generator.components.house.HouseSettings;
 import net.buildtheearth.buildteamtools.modules.generator.components.house.RoofType;
 import net.buildtheearth.buildteamtools.modules.generator.components.house.menu.WallColorMenu;
+import net.buildtheearth.buildteamtools.modules.generator.components.rail.Rail;
+import net.buildtheearth.buildteamtools.modules.generator.components.rail.RailSettings;
+import net.buildtheearth.buildteamtools.modules.generator.components.rail.menu.RailTypeMenu;
 import net.buildtheearth.buildteamtools.modules.generator.components.road.Road;
 import net.buildtheearth.buildteamtools.modules.generator.components.road.RoadSettings;
 import net.buildtheearth.buildteamtools.modules.generator.components.road.menu.RoadColorMenu;
@@ -20,6 +24,8 @@ import net.buildtheearth.buildteamtools.utils.ListUtil;
 import net.buildtheearth.buildteamtools.utils.MenuItems;
 import net.buildtheearth.buildteamtools.utils.menus.AbstractMenu;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -37,15 +43,10 @@ public class GeneratorMenu extends AbstractMenu {
     public static final String GENERATOR_INV_NAME = "What do you want to generate?";
 
     public static final int HOUSE_ITEM_SLOT = 9;
-
     public static final int ROAD_ITEM_SLOT = 11;
-
-    public static final int RAILWAY_ITEM_SLOT = 13;
-
+    public static final int RAIL_ITEM_SLOT = 13;
     public static final int TREE_ITEM_SLOT = 15;
-
     public static final int FIELD_ITEM_SLOT = 17;
-
 
     public GeneratorMenu(Player player, boolean autoLoad) {
         super(3, GENERATOR_INV_NAME, player, autoLoad);
@@ -53,83 +54,127 @@ public class GeneratorMenu extends AbstractMenu {
 
     @Override
     protected void setPreviewItems() {
-        // HOUSE ITEM
-        ArrayList<String> houseLore = ListUtil.createList("", "§eDescription:", "Generate basic building shells", "with multiple floors, windows and roofs", "", "§eFeatures:", "- " + RoofType.values().length + " Roof Types", "- Custom Wall, Base and Roof Color", "- Custom Floor and Window Sizes", "", "§8Left-click to generate", "§8Right-click for Tutorial");
+        ArrayList<String> houseLore = ListUtil.createList(
+                "",
+                "§eDescription:",
+                "Generate basic building shells",
+                "with multiple floors, windows and roofs",
+                "",
+                "§eFeatures:",
+                "- " + RoofType.values().length + " Roof Types",
+                "- Custom Wall, Base and Roof Color",
+                "- Custom Floor and Window Sizes",
+                "",
+                "§8Left-click to generate",
+                "§8Right-click for Tutorial"
+        );
 
         ItemStack houseItem = Item.create(Objects.requireNonNull(XMaterial.BIRCH_DOOR.get()), "§cGenerate House", houseLore);
-
-        // Set navigator item
         getMenu().getSlot(HOUSE_ITEM_SLOT).setItem(houseItem);
 
+        ArrayList<String> roadLore = ListUtil.createList(
+                "",
+                "§eDescription:",
+                "Generate roads and highways",
+                "with multiple lanes and sidewalks",
+                "",
+                "§eFeatures:",
+                "- Custom Road Width and Color",
+                "- Custom Sidewalk Width and Color",
+                "- Custom Lane Count",
+                "",
+                "§8Left-click to generate",
+                "§8Right-click for Tutorial"
+        );
 
-        // ROAD ITEM
-        ArrayList<String> roadLore = ListUtil.createList("", "§eDescription:", "Generate roads and highways", "with multiple lanes and sidewalks", "", "§eFeatures:", "- Custom Road Width and Color", "- Custom Sidewalk Width and Color", "- Custom Lane Count", "", "§8Left-click to generate", "§8Right-click for Tutorial");
-
-
-        ItemStack roadItem = new Item(XMaterial.SMOOTH_STONE_SLAB.parseItem()).setDisplayName("§bGenerate Road").setLore(roadLore).build();
-
-        // Set navigator item
+        ItemStack roadItem = Item.create(Objects.requireNonNull(XMaterial.SMOOTH_STONE_SLAB.get()), "§bGenerate Road", roadLore);
         getMenu().getSlot(ROAD_ITEM_SLOT).setItem(roadItem);
 
+        ArrayList<String> railwayLore = ListUtil.createList(
+                "",
+                "§eDescription:",
+                "Generate a predefined railway",
+                "from your active WorldEdit selection",
+                "",
+                "§eSupported selections:",
+                "- Cuboid",
+                "- Polygonal",
+                "- Convex",
+                "",
+                "§eFeatures:",
+                "- Rail Type selection",
+                "- Straight sections",
+                "- Direction changes",
+                "- Automatic side block orientation",
+                "",
+                "§8Left-click to generate",
+                "§8Right-click for Tutorial"
+        );
 
-        // RAILWAY ITEM
-        ArrayList<String> railwayLore = ListUtil.createList("", "§eDescription:", "Generate railways with multiple tracks", "and many different designs", "", "§eFeatures:", "- Custom Railway Width and Color (TODO)", "- Custom Track Count (TODO)", "", "§8Left-click to generate", "§8Right-click for Tutorial");
-
-        railwayLore = ListUtil.createList("", "§cThis §eGenerator §cis currently broken", "§cRailway Generator is disabled", "", "§8If you want to help fixing ask on Dev Hub!");
-
-        ItemStack railwayItem = Item.create(Objects.requireNonNull(XMaterial.RAIL.get()), "§9Generate Railway §c(DISABLED)", railwayLore);
-
-        // Set navigator item
-        getMenu().getSlot(RAILWAY_ITEM_SLOT).setItem(railwayItem);
-
+        ItemStack railwayItem = Item.create(Objects.requireNonNull(XMaterial.RAIL.get()), "§9Generate Railway", railwayLore);
+        getMenu().getSlot(RAIL_ITEM_SLOT).setItem(railwayItem);
 
         if (!CommonModule.getInstance().getDependencyComponent().isSchematicBrushEnabled()) {
-            // TREE ITEM
-            ArrayList<String> treeLore = ListUtil.createList("", "§cPlugin §eSchematicBrush §cis not installed", "§cTree Generator is disabled", "", "§8Leftclick for Installation Instructions");
+            ArrayList<String> treeLore = ListUtil.createList(
+                    "",
+                    "§cPlugin §eSchematicBrush §cis not installed",
+                    "§cTree Generator is disabled",
+                    "",
+                    "§8Leftclick for Installation Instructions"
+            );
 
             ItemStack treeItem = Item.create(Objects.requireNonNull(XMaterial.OAK_SAPLING.get()), "§aGenerate Tree & Forest §c(DISABLED)", treeLore);
-
-            // Set navigator item
             getMenu().getSlot(TREE_ITEM_SLOT).setItem(treeItem);
         } else if (!GeneratorCollections.hasUpdatedGeneratorCollections(getMenuPlayer())) {
-            // TREE ITEM
-            ArrayList<String> treeLore = ListUtil.createList("", "§cThe §eTree Pack " + Tree.TREE_PACK_VERSION + " §cis not installed", "§cTree Generator is disabled", "", "§8Leftclick for Installation Instructions");
+            ArrayList<String> treeLore = ListUtil.createList(
+                    "",
+                    "§cThe §eTree Pack " + Tree.TREE_PACK_VERSION + " §cis not installed",
+                    "§cTree Generator is disabled",
+                    "",
+                    "§8Leftclick for Installation Instructions"
+            );
 
             ItemStack treeItem = Item.create(Objects.requireNonNull(XMaterial.OAK_SAPLING.get()), "§aGenerate Tree & Forest §c(DISABLED)", treeLore);
-
-            // Set navigator item
             getMenu().getSlot(TREE_ITEM_SLOT).setItem(treeItem);
         } else {
-            // TREE ITEM
-            ArrayList<String> treeLore = ListUtil.createList("", "§eDescription:", "Generate trees from a set of", "hundreds of different types", "", "§eFeatures:", "- Custom Tree Type", "", "§8Left-click to generate", "§8Right-click for Tutorial");
+            ArrayList<String> treeLore = ListUtil.createList(
+                    "",
+                    "§eDescription:",
+                    "Generate trees from a set of",
+                    "hundreds of different types",
+                    "",
+                    "§eFeatures:",
+                    "- Custom Tree Type",
+                    "",
+                    "§8Left-click to generate",
+                    "§8Right-click for Tutorial"
+            );
 
             ItemStack treeItem = Item.create(Objects.requireNonNull(XMaterial.OAK_SAPLING.get()), "§aGenerate Tree & Forest", treeLore);
-
-            // Set navigator item
             getMenu().getSlot(TREE_ITEM_SLOT).setItem(treeItem);
         }
 
-
-        // FIELD ITEM
-        ArrayList<String> fieldLore = ListUtil.createList("", "§cThis §eGenerator §cis currently broken", "§cField Generator is disabled", "", "§8If you want to help fixing ask on Dev Hub!");
+        ArrayList<String> fieldLore = ListUtil.createList(
+                "",
+                "§cThis §eGenerator §cis currently broken",
+                "§cField Generator is disabled",
+                "",
+                "§8If you want to help fixing ask on Dev Hub!"
+        );
 
         ItemStack fieldItem = Item.create(Objects.requireNonNull(XMaterial.WHEAT.get()), "§6Generate Field §c(DISABLED)", fieldLore);
-
-        // Set navigator item
         getMenu().getSlot(FIELD_ITEM_SLOT).setItem(fieldItem);
-
 
         super.setPreviewItems();
     }
 
     @Override
     protected void setMenuItemsAsync() {
-        // No Async / DB Items
+        // No async or database items.
     }
 
     @Override
     protected void setItemClickEventsAsync() {
-        // Set click event for house item
         getMenu().getSlot(HOUSE_ITEM_SLOT).setClickHandler(((clickPlayer, clickInformation) -> {
             if (clickInformation.getClickType().equals(ClickType.RIGHT)) {
                 sendMoreInformation(clickPlayer, GeneratorType.HOUSE);
@@ -139,14 +184,14 @@ public class GeneratorMenu extends AbstractMenu {
             House house = GeneratorModule.getInstance().getHouse();
             house.getPlayerSettings().put(clickPlayer.getUniqueId(), new HouseSettings(clickPlayer));
 
-            if (!house.checkForPlayer(clickPlayer)) return;
+            if (!house.checkForPlayer(clickPlayer))
+                return;
 
             clickPlayer.closeInventory();
             clickPlayer.playSound(clickPlayer.getLocation(), Sound.UI_BUTTON_CLICK, 1.0F, 1.0F);
             new WallColorMenu(clickPlayer, true);
         }));
 
-        // Set click event for road item
         getMenu().getSlot(ROAD_ITEM_SLOT).setClickHandler(((clickPlayer, clickInformation) -> {
             if (clickInformation.getClickType().equals(ClickType.RIGHT)) {
                 sendMoreInformation(clickPlayer, GeneratorType.ROAD);
@@ -156,34 +201,31 @@ public class GeneratorMenu extends AbstractMenu {
             Road road = GeneratorModule.getInstance().getRoad();
             road.getPlayerSettings().put(clickPlayer.getUniqueId(), new RoadSettings(clickPlayer));
 
-            if (!road.checkForPlayer(clickPlayer)) return;
+            if (!road.checkForPlayer(clickPlayer))
+                return;
 
             clickPlayer.closeInventory();
             clickPlayer.playSound(clickPlayer.getLocation(), Sound.UI_BUTTON_CLICK, 1.0F, 1.0F);
             new RoadColorMenu(clickPlayer, true);
         }));
 
-        // Set click event for railway item
-        getMenu().getSlot(RAILWAY_ITEM_SLOT).setClickHandler(((clickPlayer, clickInformation) -> {
+        getMenu().getSlot(RAIL_ITEM_SLOT).setClickHandler(((clickPlayer, clickInformation) -> {
             if (clickInformation.getClickType().equals(ClickType.RIGHT)) {
-                sendMoreInformation(clickPlayer, GeneratorType.RAILWAY);
+                sendMoreInformation(clickPlayer, GeneratorType.RAIL);
                 return;
             }
-            sendMoreInformation(clickPlayer, GeneratorType.RAILWAY);
 
-            /*Rail rail = GeneratorModule.getInstance().getRail();
+            Rail rail = GeneratorModule.getInstance().getRail();
             rail.getPlayerSettings().put(clickPlayer.getUniqueId(), new RailSettings(clickPlayer));
 
-            if(!rail.checkForPlayer(clickPlayer))
+            if (!rail.checkForPlayer(clickPlayer))
                 return;
 
             clickPlayer.closeInventory();
             clickPlayer.playSound(clickPlayer.getLocation(), Sound.UI_BUTTON_CLICK, 1.0F, 1.0F);
-
-            GeneratorModule.getInstance().getRail().generate(clickPlayer);*/
+            new RailTypeMenu(clickPlayer, true);
         }));
 
-        // Set click event for tree item
         getMenu().getSlot(TREE_ITEM_SLOT).setClickHandler(((clickPlayer, clickInformation) -> {
             if (clickInformation.getClickType().equals(ClickType.RIGHT)) {
                 sendMoreInformation(clickPlayer, GeneratorType.TREE);
@@ -193,35 +235,26 @@ public class GeneratorMenu extends AbstractMenu {
             Tree tree = GeneratorModule.getInstance().getTree();
             tree.getPlayerSettings().put(clickPlayer.getUniqueId(), new TreeSettings(clickPlayer));
 
-            if (!tree.checkForPlayer(clickPlayer)) return;
+            if (!tree.checkForPlayer(clickPlayer))
+                return;
 
             clickPlayer.closeInventory();
             clickPlayer.playSound(clickPlayer.getLocation(), Sound.UI_BUTTON_CLICK, 1.0F, 1.0F);
             new TreeTypeMenu(clickPlayer, true);
         }));
 
-        // Set click event for field item
         getMenu().getSlot(FIELD_ITEM_SLOT).setClickHandler(((clickPlayer, clickInformation) -> {
-            if (clickInformation.getClickType().equals(ClickType.RIGHT)) {
-                sendMoreInformation(clickPlayer, GeneratorType.FIELD);
-                return;
-            }
             sendMoreInformation(clickPlayer, GeneratorType.FIELD);
-
-            /*Field field = GeneratorModule.getInstance().getField();
-            field.getPlayerSettings().put(clickPlayer.getUniqueId(), new FieldSettings(clickPlayer));
-
-            if(!field.checkForPlayer(clickPlayer))
-                return;
-
-            clickPlayer.closeInventory();
-            clickPlayer.playSound(clickPlayer.getLocation(), Sound.UI_BUTTON_CLICK, 1.0F, 1.0F);
-            new CropTypeMenu(clickPlayer, true);*/
         }));
     }
 
     private void sendMoreInformation(@NonNull Player clickPlayer, @NonNull GeneratorType generator) {
-        clickPlayer.sendMessage(Component.text(generator.getWikiPage(), NamedTextColor.RED));
+        String wikiPage = generator.getWikiPage();
+        Component documentationLink = ChatHelper.getStandardComponent(true, "Open generator documentation: %s", wikiPage)
+                .clickEvent(ClickEvent.openUrl(wikiPage))
+                .hoverEvent(HoverEvent.showText(Component.text("Click to open this page", NamedTextColor.GRAY)));
+
+        clickPlayer.sendMessage(documentationLink);
     }
 
     @Override

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/BlockChange.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/BlockChange.java
@@ -1,0 +1,58 @@
+package net.buildtheearth.buildteamtools.modules.generator.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+
+public class BlockChange {
+
+    @Getter
+    private final String worldName;
+
+    @Getter
+    private final int x;
+
+    @Getter
+    private final int y;
+
+    @Getter
+    private final int z;
+
+    @Getter
+    private final String oldBlockData;
+
+    @Getter
+    @Setter
+    private String newBlockData;
+
+    public BlockChange(String worldName, int x, int y, int z, String oldBlockData, String newBlockData) {
+        this.worldName = worldName;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.oldBlockData = oldBlockData;
+        this.newBlockData = newBlockData;
+    }
+
+    public void applyOld() {
+        apply(oldBlockData);
+    }
+
+    public void applyNew() {
+        apply(newBlockData);
+    }
+
+    private void apply(String blockDataString) {
+        World world = Bukkit.getWorld(worldName);
+
+        if (world == null)
+            return;
+
+        Block block = world.getBlockAt(x, y, z);
+        BlockData blockData = Bukkit.createBlockData(blockDataString);
+        block.setBlockData(blockData, false);
+    }
+}

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/Command.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/Command.java
@@ -11,8 +11,10 @@ import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import lombok.Getter;
-import net.buildtheearth.buildteamtools.BuildTeamTools;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.buildtheearth.buildteamtools.modules.common.CommonModule;
+import net.buildtheearth.buildteamtools.modules.generator.listeners.GeneratorListener;
 import net.buildtheearth.buildteamtools.utils.MenuItems;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -21,7 +23,8 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -54,7 +57,11 @@ public class Command {
     @Getter
     private final LocalSession localSession;
 
-    private final int totalCommands;
+    private final long totalProgressWeight;
+    private final long progressStartPercentage;
+    private final long progressEndPercentage;
+    private final long progressRangePercentage;
+    private long completedProgressWeight;
 
     @Getter
     private long percentage;
@@ -65,6 +72,7 @@ public class Command {
     private RegionSelector tempRegionSelector;
     private Material oldMaterial;
     private BlockData oldBlockData;
+    private boolean failed;
 
     @Getter
     private boolean isFinished;
@@ -80,49 +88,48 @@ public class Command {
         this.localSession = script.localSession;
         this.blocks = blocks;
 
-        this.totalCommands = operations.size();
+        this.totalProgressWeight = Math.max(1L, operations.stream().mapToLong(Operation::getProgressWeight).sum());
+        this.progressStartPercentage = script.getProgressStartPercentage();
+        this.progressEndPercentage = script.getProgressEndPercentage();
+        this.progressRangePercentage = progressEndPercentage - progressStartPercentage;
+        this.percentage = progressStartPercentage;
+
         minMax = GeneratorUtils.getMinMaxPoints(getRegion());
     }
 
-    /**
-     * Processes the commands from the command queue to prevent the server from freezing.
-     */
+    /** Processes the commands from the command queue to prevent the server from freezing. */
     public void tick() {
         if (operations.isEmpty()) {
-            if (!isFinished)
+            if (!isFinished && !failed)
                 finish();
             return;
         }
 
-        percentage = (int) Math.round((double) (totalCommands - operations.size()) / (double) totalCommands * 100);
+        percentage = calculateProgressPercentage();
 
-        if (!breakPointActive && !threadActive)
-            player.sendActionBar("§a§lGenerator Progress: §7" + percentage + "%");
-        else
-            player.sendActionBar("§e§lGenerator Progress: §7" + percentage + "%");
+        sendProgressActionBar(!breakPointActive && !threadActive ? NamedTextColor.GREEN : NamedTextColor.YELLOW);
 
         if (threadActive)
             return;
 
-
         // Process commands in batches of MAX_COMMANDS_PER_SERVER_TICK
-        for (int i = 0; i < MAX_COMMANDS_PER_SERVER_TICK; ) {
+        for (int i = 0; i < MAX_COMMANDS_PER_SERVER_TICK;) {
             if (operations.isEmpty()) {
-                if (!isFinished)
+                if (!isFinished && !failed)
                     finish();
                 break;
             }
 
-
             Operation command = operations.get(0);
             processOperation(command);
 
-            if (breakPointActive || threadActive)
+            if (breakPointActive || threadActive || command.getProgressWeight() > 1L)
                 break;
 
             // Skip WorldEdit commands that take no time to execute
             if (command.getOperationType() == Operation.OperationType.COMMAND) {
-                String commandString = (String) command.getValues().get(0);
+                String commandString = command.get(0, String.class);
+
                 if (commandString.startsWith("//gmask")
                         || commandString.startsWith("//mask")
                         || commandString.startsWith("//pos")
@@ -135,9 +142,7 @@ public class Command {
         }
     }
 
-    /**
-     * Processes a single command.
-     */
+    /** Processes a single command. */
     public void processOperation(Operation operation) {
         CompletableFuture<Void> future = null;
 
@@ -149,7 +154,7 @@ public class Command {
                     if (command.contains("%%XYZ/"))
                         command = convertXYZ(command);
 
-                    player.chat(command);
+                    runInternalGeneratorCommand(command);
                     break;
 
                 case BREAKPOINT:
@@ -186,35 +191,100 @@ public class Command {
                     break;
 
                 case REPLACE_BLOCKSTATES_WITH_MASKS:
-                    future = GeneratorUtils.replaceBlocksWithMasks(localSession, actor, weWorld, Arrays.asList((String[]) operation.get(0)), (BlockState) operation.get(1), (BlockState[]) operation.get(2), (Integer) operation.get(3));
+                    future = GeneratorUtils.replaceBlocksWithMasks(
+                            localSession,
+                            actor,
+                            weWorld,
+                            toList(operation.get(0, String[].class)),
+                            operation.get(1, BlockState.class),
+                            operation.get(2, BlockState[].class),
+                            operation.get(3, Integer.class)
+                    );
                     break;
 
                 case REPLACE_BLOCKSTATES:
-                    future = GeneratorUtils.replaceBlocks(localSession, actor, weWorld, (BlockState[]) operation.get(0), (BlockState[]) operation.get(1));
+                    future = GeneratorUtils.replaceBlocks(
+                            localSession,
+                            actor,
+                            weWorld,
+                            operation.get(0, BlockState[].class),
+                            operation.get(1, BlockState[].class)
+                    );
+                    break;
+
+                case SET_BLOCKSTATES_AT_POSITIONS:
+                    future = GeneratorUtils.setBlockStatesAtPositions(
+                            localSession,
+                            actor,
+                            weWorld,
+                            toList(operation.get(0, Vector[].class)),
+                            toList(operation.get(1, BlockState[].class))
+                    );
                     break;
 
                 case DRAW_CURVE_WITH_MASKS:
-                    future = GeneratorUtils.drawCurveWithMasks(localSession, actor, weWorld, blocks, Arrays.asList((String[]) operation.get(0)), Arrays.asList((Vector[]) operation.get(1)), (BlockState[]) operation.get(2), (Boolean) operation.get(3));
+                    future = GeneratorUtils.drawCurveWithMasks(
+                            localSession,
+                            actor,
+                            weWorld,
+                            blocks,
+                            toList(operation.get(0, String[].class)),
+                            toList(operation.get(1, Vector[].class)),
+                            operation.get(2, BlockState[].class),
+                            operation.get(3, Boolean.class)
+                    );
                     break;
 
                 case DRAW_POLY_LINE_WITH_MASKS:
-                    future = GeneratorUtils.drawPolyLineWithMasks(localSession, actor, weWorld, blocks, Arrays.asList((String[]) operation.get(0)), Arrays.asList((Vector[]) operation.get(1)), (BlockState[]) operation.get(2), (Boolean) operation.get(3), (Boolean) operation.get(4));
+                    future = GeneratorUtils.drawPolyLineWithMasks(
+                            localSession,
+                            actor,
+                            weWorld,
+                            blocks,
+                            toList(operation.get(0, String[].class)),
+                            toList(operation.get(1, Vector[].class)),
+                            operation.get(2, BlockState[].class),
+                            operation.get(3, Boolean.class),
+                            operation.get(4, Boolean.class)
+                    );
                     break;
 
                 case DRAW_LINE_WITH_MASKS:
-                    future = GeneratorUtils.drawLineWithMasks(localSession, actor, weWorld, blocks, Arrays.asList((String[]) operation.get(0)), (Vector) operation.get(1), (Vector) operation.get(2), (BlockState[]) operation.get(3), (Boolean) operation.get(4));
+                    future = GeneratorUtils.drawLineWithMasks(
+                            localSession,
+                            actor,
+                            weWorld,
+                            blocks,
+                            toList(operation.get(0, String[].class)),
+                            operation.get(1, Vector.class),
+                            operation.get(2, Vector.class),
+                            operation.get(3, BlockState[].class),
+                            operation.get(4, Boolean.class)
+                    );
                     break;
 
                 case PASTE_SCHEMATIC:
-                    future = GeneratorUtils.pasteSchematic(localSession, actor, weWorld, blocks, (String) operation.get(0), (Location) operation.get(1), (double) operation.get(2));
+                    future = GeneratorUtils.pasteSchematic(
+                            localSession,
+                            actor,
+                            weWorld,
+                            blocks,
+                            operation.get(0, String.class),
+                            operation.get(1, Location.class),
+                            operation.get(2, Double.class)
+                    );
                     break;
 
                 case CUBOID_SELECTION:
-                    GeneratorUtils.createCuboidSelection(getPlayer(), (Vector) operation.get(0), (Vector) operation.get(1));
+                    GeneratorUtils.createCuboidSelection(
+                            getPlayer(),
+                            operation.get(0, Vector.class),
+                            operation.get(1, Vector.class)
+                    );
                     break;
 
                 case POLYGONAL_SELECTION:
-                    GeneratorUtils.createPolySelection(getPlayer(), Arrays.asList((Vector[]) operation.get(0)), blocks);
+                    GeneratorUtils.createPolySelection(getPlayer(), toList(operation.get(0, Vector[].class)), blocks);
                     break;
 
                 case CLEAR_HISTORY:
@@ -222,43 +292,102 @@ public class Command {
                     break;
 
                 case SET_GMASK:
-                    GeneratorUtils.setGmask(localSession, (String) operation.get(0));
+                    GeneratorUtils.setGmask(localSession, operation.get(0, String.class));
                     break;
 
                 case EXPAND_SELECTION:
-                    GeneratorUtils.expandSelection(localSession, (Vector) operation.get(0));
+                    GeneratorUtils.expandSelection(localSession, operation.get(0, Vector.class));
                     break;
             }
         } catch (Exception e) {
-            if (operation != null)
-                ChatHelper.logError("Error while processing command: " + operation.getOperationType() + " - " + operation.getValuesAsString());
-            else
-                ChatHelper.logError("Error while processing command.");
-            BuildTeamTools.getInstance().getComponentLogger().error("Command processing error", e);
+            ChatHelper.logError("Error while processing command: " + operation.getOperationType() + " - " + operation.getValuesAsString());
+            ChatHelper.logError("Generator command processing failed.", e);
+            failGeneration();
+            return;
         }
 
         if (future != null) {
             threadActive = true;
+
             // Ensure we clear threadActive and remove the operation regardless of success or exception
             future.whenComplete((v, ex) -> {
                 threadActive = false;
+
                 if (ex != null) {
                     ChatHelper.logError("Async operation failed: " + operation.getOperationType() + " - " + operation.getValuesAsString());
-                    BuildTeamTools.getInstance().getComponentLogger().error("Async operation failed", ex);
+                    ChatHelper.logError("Generator async operation failed.", new Exception(ex));
+                    failGeneration();
+                    return;
                 }
-                // Remove the processed operation from the queue
-                operations.removeFirst();
-            });
 
-        } else if (!breakPointActive)
-            operations.removeFirst();
+                completeOperation(operation);
+            });
+        } else if (!breakPointActive) {
+            completeOperation(operation);
+        }
     }
 
-    /**
-     * Converts the XYZ coordinates in a command to the highest block at that location while skipping certain blocks.
-     */
+    private long calculateProgressPercentage() {
+        if (operations.isEmpty())
+            return progressEndPercentage;
+
+        long scaledProgress = progressStartPercentage + Math.round(
+                (double) completedProgressWeight / (double) totalProgressWeight * progressRangePercentage
+        );
+        long maxVisibleProgress = Math.max(progressStartPercentage, progressEndPercentage - 1L);
+
+        return Math.max(progressStartPercentage, Math.min(scaledProgress, maxVisibleProgress));
+    }
+
+    private void completeOperation(Operation operation) {
+        completedProgressWeight += operation.getProgressWeight();
+        operations.removeFirst();
+    }
+
+    private void failGeneration() {
+        if (isFinished)
+            return;
+
+        failed = true;
+        isFinished = true;
+        operations.clear();
+        sendGeneratorError();
+        sendFailureActionBar();
+    }
+
+    private void sendGeneratorError() {
+        generatorComponent.sendError(player);
+    }
+
+    private void sendFailureActionBar() {
+        player.sendActionBar(Component.text("Generator failed.", NamedTextColor.RED));
+    }
+
+    private void sendProgressActionBar(NamedTextColor color) {
+        player.sendActionBar(ChatHelper.getStandardComponent(false, "Generator Progress: %s", percentage + "%").color(color));
+    }
+
+    private void runInternalGeneratorCommand(String command) {
+        GeneratorListener.queueInternalGeneratorCommand(player, command);
+
+        try {
+            player.chat(command);
+        } finally {
+            GeneratorListener.removeInternalGeneratorCommand(player, command);
+        }
+    }
+
+    private static <T> List<T> toList(T[] values) {
+        List<T> list = new ArrayList<>(values.length);
+        Collections.addAll(list, values);
+        return list;
+    }
+
+    /** Converts the XYZ coordinates in a command to the highest block at that location while skipping certain blocks. */
     public String convertXYZ(String command) {
-        String xyz = command.split("%%XYZ/")[1].split("/%%")[0];
+        String[] commandParts = command.split("%%XYZ/", 2);
+        String[] xyzParts = commandParts[1].split("/%%", 2);
+        String xyz = xyzParts[0];
 
         String[] xyzSplit = xyz.split(",");
         int x = Integer.parseInt(xyzSplit[0]);
@@ -269,22 +398,19 @@ public class Command {
 
         if (blocks != null)
             maxHeight = GeneratorUtils.getMaxHeight(blocks, x, z, MenuItems.getIgnoredMaterials());
+
         if (maxHeight == 0)
             maxHeight = y;
 
-        String commandSuffix = "";
-        if (command.split("/%%").length > 1)
-            commandSuffix = command.split("/%%")[1];
+        String commandSuffix = xyzParts.length > 1 ? xyzParts[1] : "";
 
-        return command.split("%%XYZ/")[0] + x + "," + maxHeight + "," + z + commandSuffix;
+        return commandParts[0] + x + "," + maxHeight + "," + z + commandSuffix;
     }
 
-
-    /**
-     * Called when the command queue is finished.
-     */
+    /** Called when the command queue is finished. */
     public void finish() {
-        player.sendActionBar("§a§lGenerator Progress: §7100%");
+        percentage = progressEndPercentage;
+        sendProgressActionBar(NamedTextColor.GREEN);
         isFinished = true;
         generatorComponent.sendSuccessMessage(player);
     }

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/Flag.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/Flag.java
@@ -21,7 +21,7 @@ public interface Flag {
             case HOUSE -> HouseFlag.byString(flag);
             case ROAD -> RoadFlag.byString(flag);
             case TREE -> TreeFlag.byString(flag);
-            case RAILWAY -> RailFlag.byString(flag);
+            case RAIL -> RailFlag.byString(flag);
             case FIELD -> FieldFlag.byString(flag);
         };
     }

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/FlagType.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/FlagType.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import net.buildtheearth.buildteamtools.modules.generator.components.field.CropStage;
 import net.buildtheearth.buildteamtools.modules.generator.components.field.CropType;
 import net.buildtheearth.buildteamtools.modules.generator.components.house.RoofType;
+import net.buildtheearth.buildteamtools.modules.generator.components.rail.RailType;
 import net.buildtheearth.buildteamtools.modules.generator.components.tree.TreeType;
 import net.buildtheearth.buildteamtools.modules.generator.components.tree.TreeWidth;
 
@@ -22,6 +23,7 @@ public enum FlagType {
     ROOF_TYPE(RoofType.class),
     CROP_TYPE(CropType.class),
     CROP_STAGE(CropStage.class),
+    RAIL_TYPE(RailType.class),
     TREE_TYPE(TreeType.class),
     TREE_WIDTH(TreeWidth.class);
 
@@ -88,6 +90,8 @@ public enum FlagType {
                 return CropType.getByIdentifier(value);
             case CROP_STAGE:
                 return CropStage.getByIdentifier(value);
+            case RAIL_TYPE:
+                return RailType.byString(value);
             case TREE_TYPE:
                 return TreeType.byString(value);
             case TREE_WIDTH:

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/GeneratorCollections.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/GeneratorCollections.java
@@ -71,7 +71,6 @@ public class GeneratorCollections {
         }
     }
 
-
     /**
      * Returns the latest release version of a repository on GitHub
      *

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/GeneratorComponent.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/GeneratorComponent.java
@@ -1,9 +1,9 @@
 package net.buildtheearth.buildteamtools.modules.generator.model;
 
 import com.alpsbte.alpslib.utils.GeneratorUtils;
+import com.alpsbte.alpslib.utils.ChatHelper;
 import com.alpsbte.alpslib.utils.WikiDocumented;
 import lombok.Getter;
-import net.buildtheearth.buildteamtools.BuildTeamTools;
 import net.buildtheearth.buildteamtools.modules.ModuleComponent;
 import net.buildtheearth.buildteamtools.modules.generator.components.field.FieldSettings;
 import net.buildtheearth.buildteamtools.modules.generator.components.house.HouseSettings;
@@ -16,7 +16,6 @@ import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NonNull;
@@ -40,12 +39,24 @@ public abstract class GeneratorComponent extends ModuleComponent implements Wiki
 
     public abstract void generate(Player p);
 
-
     public void analyzeCommand(Player p, String[] args) {
-        sendHelp(p, args);
+        if (isHelpCommand(args)) {
+            sendHelp(p);
+            return;
+        }
+
         addPlayerSetting(p);
-        convertArgsToSettings(p, args);
+        if (!convertArgsToSettings(p, args))
+            return;
+
         generate(p);
+    }
+
+    private boolean isHelpCommand(String[] args) {
+        return args.length == 2
+                && (args[1].equalsIgnoreCase("info")
+                || args[1].equalsIgnoreCase("help")
+                || args[1].equalsIgnoreCase("?"));
     }
 
     public void addPlayerSetting(UUID uuid, Settings settings) {
@@ -60,7 +71,7 @@ public abstract class GeneratorComponent extends ModuleComponent implements Wiki
             case ROAD:
                 addPlayerSetting(p.getUniqueId(), new RoadSettings(p));
                 break;
-            case RAILWAY:
+            case RAIL:
                 addPlayerSetting(p.getUniqueId(), new RailSettings(p));
                 break;
             case TREE:
@@ -72,23 +83,20 @@ public abstract class GeneratorComponent extends ModuleComponent implements Wiki
         }
     }
 
-    public void sendHelp(Player p, String @NonNull [] args) {
-        if (args.length == 2 && (args[1].equals("info") || args[1].equals("help") || args[1].equals("?")))
-            sendHelp(p);
-    }
-
     public void sendHelp(@NonNull Player p) {
-        p.sendMessage(Component.text(getWikiPage(), NamedTextColor.YELLOW));
-    }
+        String wikiPage = getWikiPage();
+        Component wikiLink = Component.text(wikiPage, NamedTextColor.YELLOW)
+                .clickEvent(ClickEvent.openUrl(wikiPage))
+                .hoverEvent(HoverEvent.showText(Component.text("Click to open this page", NamedTextColor.GRAY)));
 
-    public void sendMoreInfo(Player p) {
-        p.sendMessage(" ");
-        p.sendMessage("§cFor more information take a look at the wiki:");
-        p.sendMessage("§c" + getWikiPage());
+        p.sendMessage(ChatHelper.PREFIX_COMPONENT.append(wikiLink));
     }
 
     public void sendError(Player p) {
-        p.sendMessage("§cThere was an error while generating the house. Please contact the admins");
+        p.sendMessage(ChatHelper.PREFIX_COMPONENT.append(ChatHelper.getErrorComponent(
+                "There was an error while generating the %s. Please contact the admins.",
+                generatorType.getName().toLowerCase()
+        )));
     }
 
     public String getCommand(@NonNull Player p) {
@@ -97,7 +105,7 @@ public abstract class GeneratorComponent extends ModuleComponent implements Wiki
         String type = switch (generatorType) {
             case HOUSE -> "house";
             case ROAD -> "road";
-            case RAILWAY -> "railway";
+            case RAIL -> "rail";
             case TREE -> "tree";
             case FIELD -> "field";
         };
@@ -112,15 +120,18 @@ public abstract class GeneratorComponent extends ModuleComponent implements Wiki
 
     public void sendSuccessMessage(Player p) {
         TextComponent copyCommand = Component.text("[COPY]", NamedTextColor.YELLOW, TextDecoration.BOLD)
-                .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.SUGGEST_COMMAND, getCommand(p)))
+                .clickEvent(ClickEvent.suggestCommand(getCommand(p)))
                 .hoverEvent(HoverEvent.showText(Component.text("Click to copy command", NamedTextColor.GRAY)));
 
         TextComponent undo = Component.text("[UNDO]", NamedTextColor.RED, TextDecoration.BOLD)
                 .clickEvent(ClickEvent.runCommand("/gen undo"))
                 .hoverEvent(HoverEvent.showText(Component.text("Click to undo last generation", NamedTextColor.GRAY)));
 
-        TextComponent message =
-                getMessage().append(Component.text(" ")).append(copyCommand).append(Component.text(" ")).append(undo);
+        TextComponent message = getMessage()
+                .append(Component.text(" "))
+                .append(copyCommand)
+                .append(Component.text(" "))
+                .append(undo);
 
         p.sendMessage(message);
         p.playSound(p.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1.0F, 1.0F);
@@ -130,13 +141,15 @@ public abstract class GeneratorComponent extends ModuleComponent implements Wiki
         String type = switch (generatorType) {
             case HOUSE -> "House";
             case ROAD -> "Road";
-            case RAILWAY -> "Railway";
+            case RAIL -> "Rail";
             case TREE -> "Tree";
             case FIELD -> "Field";
         };
 
-        return LegacyComponentSerializer.legacyAmpersand().deserialize(BuildTeamTools.PREFIX + type + "§a successfully " +
-                "§7generated.");
+        return ChatHelper.PREFIX_COMPONENT
+                .append(Component.text(type, NamedTextColor.GRAY))
+                .append(Component.text(" successfully ", NamedTextColor.GREEN))
+                .append(Component.text("generated.", NamedTextColor.GRAY));
     }
 
     /**
@@ -145,22 +158,28 @@ public abstract class GeneratorComponent extends ModuleComponent implements Wiki
      * args: ["-w", "123:12", "-r", "456:78"]
      * HouseSettings:
      * WALL_COLOR: 123:12
-     * ROOF_TYPE:  456:78
+     * ROOF_TYPE: 456:78
      */
-    protected void convertArgsToSettings(Player p, String[] args) {
+    protected boolean convertArgsToSettings(Player p, String[] args) {
+        boolean convertedFlag = false;
+
         for (String flag : GeneratorUtils.convertArgsToFlags(args)) {
             String[] flagAndValue = GeneratorUtils.convertToFlagAndValue(flag, p);
 
-            if (flagAndValue == null) continue;
+            if (flagAndValue == null)
+                continue;
 
             String flagName = flagAndValue[0];
 
-            if (flagName == null) continue;
+            if (flagName == null)
+                continue;
 
             Flag finalFlag = Flag.byString(generatorType, flagName);
 
-            if (finalFlag == null) continue;
+            if (finalFlag == null)
+                continue;
 
+            convertedFlag = true;
             Object flagValue = FlagType.convertToFlagType(finalFlag, flagAndValue[1]);
 
             String errorMessage = FlagType.validateFlagType(finalFlag, flagValue);
@@ -173,8 +192,12 @@ public abstract class GeneratorComponent extends ModuleComponent implements Wiki
             getPlayerSettings().get(p.getUniqueId()).setValue(finalFlag, flagValue);
         }
 
-        if (getPlayerSettings().get(p.getUniqueId()).getValues().isEmpty() && args.length > 1)
+        if (!convertedFlag && args.length > 1) {
             sendHelp(p);
+            return false;
+        }
+
+        return true;
     }
 
     @Override

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/GeneratorType.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/GeneratorType.java
@@ -7,7 +7,7 @@ public enum GeneratorType {
 
     HOUSE("House", WikiLinks.Gen.HOUSE),
     ROAD("Road", WikiLinks.Gen.ROAD),
-    RAILWAY("Railway", WikiLinks.Gen.RAIL),
+    RAIL("Rail", WikiLinks.Gen.RAIL),
     TREE("Tree", WikiLinks.Gen.TREE),
     FIELD("Field", WikiLinks.Gen.FIELD);
 

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/History.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/History.java
@@ -5,12 +5,10 @@ import com.alpsbte.alpslib.utils.GeneratorUtils;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.extension.platform.Actor;
 import lombok.Getter;
-import net.buildtheearth.buildteamtools.BuildTeamTools;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
@@ -35,83 +33,72 @@ public class History {
 
     public void addHistoryEntry(HistoryEntry entry) {
         historyEntries.add(entry);
+        undoHistoryEntries.clear();
     }
 
     public void undoCommand(Player p) {
         if (getHistoryEntries().isEmpty()) {
-            p.sendMessage("§cYou didn't generate any structures yet. Use /gen to create one. You can only undo the last " +
-                    "structure.");
+            p.sendMessage(ChatHelper.PREFIX_COMPONENT.append(ChatHelper.getErrorComponent(
+                    "You didn't generate any structures yet. Use /gen to create one. You can only undo the last structure."
+            )));
             return;
         }
 
-        LocalSession session = getHistoryEntries().get(0).getScript().getLocalSession();
-        Actor actor = getHistoryEntries().get(0).getScript().getActor();
-        int worldEditCommandCount = getHistoryEntries().get(0).getWorldEditCommandCount();
+        HistoryEntry entry = getHistoryEntries().getLast();
 
-        GeneratorUtils.undo(session, p, actor, worldEditCommandCount);
+        if (entry.hasBlockChanges()) {
+            entry.applyUndo();
+        } else {
+            LocalSession session = entry.getScript().getLocalSession();
+            Actor actor = entry.getScript().getActor();
+            int worldEditCommandCount = entry.getWorldEditCommandCount();
 
-        getUndoHistoryEntries().add(getHistoryEntries().get(0));
-        getHistoryEntries().clear();
+            GeneratorUtils.undo(session, p, actor, worldEditCommandCount);
+        }
+
+        getUndoHistoryEntries().add(entry);
+        getHistoryEntries().remove(entry);
 
         p.playSound(p.getLocation(), Sound.ENTITY_ZOMBIE_DESTROY_EGG, 1.0F, 1.0F);
 
-        Bukkit.getScheduler().scheduleSyncDelayedTask(BuildTeamTools.getInstance(), () -> {
-            ChatHelper.sendSuccessfulMessage(p, "Successfully %s the last structure.", "undid");
-            p.sendMessage(ChatHelper.getStandardComponent(true, "Use %s to undo it.", "/gen redo")
-                    .clickEvent(ClickEvent.runCommand("/gen redo"))
-                    .hoverEvent(HoverEvent.showText(Component.text("Click to redo the last structure.", NamedTextColor.GRAY)))
-            );
-            p.playSound(p.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1.0F, 1.0F);
-        }, 20L);
+        ChatHelper.sendSuccessfulMessage(p, "Successfully %s the last structure.", "undid");
+        p.sendMessage(ChatHelper.getStandardComponent(true, "Use %s to redo it.", "/gen redo")
+                .clickEvent(ClickEvent.runCommand("/gen redo"))
+                .hoverEvent(HoverEvent.showText(Component.text("Click to redo the last structure.", NamedTextColor.GRAY)))
+        );
+        p.playSound(p.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1.0F, 1.0F);
     }
 
     public void redoCommand(Player p) {
         if (getUndoHistoryEntries().isEmpty()) {
-            p.sendMessage("§cYou didn't undo any structures yet. Use /gen undo to undo one. You can only redo the last " +
-                    "structure.");
+            p.sendMessage(ChatHelper.PREFIX_COMPONENT.append(ChatHelper.getErrorComponent(
+                    "You didn't undo any structures yet. Use /gen undo to undo one. You can only redo the last structure."
+            )));
             return;
         }
 
-        LocalSession session = getUndoHistoryEntries().get(0).getScript().getLocalSession();
-        Actor actor = getUndoHistoryEntries().get(0).getScript().getActor();
-        int worldEditCommandCount = getUndoHistoryEntries().get(0).getWorldEditCommandCount();
+        HistoryEntry entry = getUndoHistoryEntries().getLast();
 
-        GeneratorUtils.redo(session, p, actor, worldEditCommandCount);
+        if (entry.hasBlockChanges()) {
+            entry.applyRedo();
+        } else {
+            LocalSession session = entry.getScript().getLocalSession();
+            Actor actor = entry.getScript().getActor();
+            int worldEditCommandCount = entry.getWorldEditCommandCount();
 
-        getHistoryEntries().add(getUndoHistoryEntries().get(0));
-        getUndoHistoryEntries().clear();
+            GeneratorUtils.redo(session, p, actor, worldEditCommandCount);
+        }
+
+        getHistoryEntries().add(entry);
+        getUndoHistoryEntries().remove(entry);
 
         p.playSound(p.getLocation(), Sound.ENTITY_ZOMBIE_DESTROY_EGG, 1.0F, 1.0F);
 
-
-        Bukkit.getScheduler().scheduleSyncDelayedTask(BuildTeamTools.getInstance(), () -> {
-            ChatHelper.sendSuccessfulMessage(p, "Successfully %s the last structure.", "redid");
-            p.sendMessage(ChatHelper.getStandardComponent(true, "Use %s to undo it.", "/gen undo")
-                    .clickEvent(ClickEvent.runCommand("/gen undo"))
-                    .hoverEvent(HoverEvent.showText(Component.text("Click to undo the last structure.", NamedTextColor.GRAY)))
-            );
-            p.playSound(p.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1.0F, 1.0F);
-        }, 20L);
-    }
-
-    public static class HistoryEntry {
-
-        @Getter
-        private final GeneratorType generatorType;
-        @Getter
-        private final long timeCreated;
-        @Getter
-        private final Script script;
-        @Getter
-        private final int worldEditCommandCount;
-
-        public HistoryEntry(GeneratorType generatorType, Script script) {
-            this.generatorType = generatorType;
-            this.timeCreated = System.currentTimeMillis();
-            this.worldEditCommandCount = script.getChanges();
-            this.script = script;
-        }
+        ChatHelper.sendSuccessfulMessage(p, "Successfully %s the last structure.", "redid");
+        p.sendMessage(ChatHelper.getStandardComponent(true, "Use %s to undo it.", "/gen undo")
+                .clickEvent(ClickEvent.runCommand("/gen undo"))
+                .hoverEvent(HoverEvent.showText(Component.text("Click to undo the last structure.", NamedTextColor.GRAY)))
+        );
+        p.playSound(p.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1.0F, 1.0F);
     }
 }
-
-

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/HistoryEntry.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/HistoryEntry.java
@@ -1,0 +1,46 @@
+package net.buildtheearth.buildteamtools.modules.generator.model;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class HistoryEntry {
+
+    @Getter
+    private final GeneratorType generatorType;
+
+    @Getter
+    private final long timeCreated;
+
+    @Getter
+    private final Script script;
+
+    @Getter
+    private final int worldEditCommandCount;
+
+    @Getter
+    private final List<BlockChange> blockChanges;
+
+    public HistoryEntry(GeneratorType generatorType, Script script) {
+        this.generatorType = generatorType;
+        this.timeCreated = System.currentTimeMillis();
+        this.worldEditCommandCount = script.getChanges();
+        this.script = script;
+        this.blockChanges = new ArrayList<>();
+    }
+
+    public boolean hasBlockChanges() {
+        return blockChanges != null && !blockChanges.isEmpty();
+    }
+
+    public void applyUndo() {
+        for (int i = blockChanges.size() - 1; i >= 0; i--)
+            blockChanges.get(i).applyOld();
+    }
+
+    public void applyRedo() {
+        for (BlockChange blockChange : blockChanges)
+            blockChange.applyNew();
+    }
+}

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/Operation.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/Operation.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -19,6 +20,7 @@ public class Operation {
         CUBOID_SELECTION(Vector.class, Vector.class),
         POLYGONAL_SELECTION(Vector[].class),
         REPLACE_BLOCKSTATES(BlockState[].class, BlockState[].class),
+        SET_BLOCKSTATES_AT_POSITIONS(Vector[].class, BlockState[].class),
         REPLACE_BLOCKSTATES_WITH_MASKS(String[].class, BlockState.class, BlockState[].class, Integer.class),
         DRAW_CURVE_WITH_MASKS(String[].class, Vector[].class, BlockState[].class, Boolean.class),
         DRAW_POLY_LINE_WITH_MASKS(String[].class, Vector[].class, BlockState[].class, Boolean.class, Boolean.class),
@@ -65,7 +67,8 @@ public class Operation {
             if (values[i] != null && !values[i].getClass().equals(operationType.getValueTypes()[i]))
                 throw new IllegalArgumentException("OperationType " + operationType + " must have a value type of " + operationType.getValueTypes()[i] + " at index " + i + ". Provided: " + values[i].getClass());
 
-        this.values = Arrays.asList(values);
+        this.values = new ArrayList<>(values.length);
+        Collections.addAll(this.values, values);
         this.operationType = operationType;
     }
 
@@ -80,33 +83,42 @@ public class Operation {
         return values.get(i);
     }
 
+    public <T> T get(int i, Class<T> type) {
+        return type.cast(values.get(i));
+    }
+
+    public long getProgressWeight() {
+        if (values == null)
+            return 0L;
+
+        return switch (operationType) {
+            case CUBOID_SELECTION, POLYGONAL_SELECTION, CLEAR_HISTORY, SET_GMASK, EXPAND_SELECTION, BREAKPOINT -> 0L;
+            case SET_BLOCKSTATES_AT_POSITIONS -> ((Vector[]) values.get(0)).length;
+            case REPLACE_BLOCKSTATES_WITH_MASKS -> (long) ((String[]) values.get(0)).length * (Integer) values.get(3);
+            case DRAW_CURVE_WITH_MASKS, DRAW_POLY_LINE_WITH_MASKS -> ((Vector[]) values.get(1)).length;
+            default -> 1L;
+        };
+    }
+
     public String getValuesAsString() {
         StringBuilder builder = new StringBuilder();
         for (Object value : values) {
-            if (value == null) {
-                builder.append("null, ");
-                continue;
-            }
-
-            String valueString = value.toString();
-
-            if (value instanceof BlockState)
-                valueString = ((BlockState) value).getBlockType().getNamespace();
-            else if (value instanceof Vector[])
-                valueString = Arrays.toString((Vector[]) value);
-            else if (value instanceof BlockState[])
-                valueString = Arrays.toString((BlockState[]) value);
-            else if (value instanceof String[])
-                valueString = Arrays.toString((String[]) value);
-            else if (value instanceof Boolean)
-                valueString = ((Boolean) value).toString();
-            else if (value instanceof Double)
-                valueString = String.valueOf(value);
-            else if (value instanceof Integer)
-                valueString = String.valueOf(value);
-
-            builder.append(valueString).append(", ");
+            builder.append(getValueAsString(value)).append(", ");
         }
         return builder.toString();
+    }
+
+    private String getValueAsString(Object value) {
+        return switch (value) {
+            case null -> "null";
+            case BlockState blockState -> blockState.getBlockType().getNamespace();
+            case Vector[] vectors -> Arrays.toString(vectors);
+            case BlockState[] blockStates -> Arrays.toString(blockStates);
+            case String[] strings -> Arrays.toString(strings);
+            case Boolean bool -> bool.toString();
+            case Double doubleValue -> String.valueOf(doubleValue);
+            case Integer integer -> String.valueOf(integer);
+            default -> value.toString();
+        };
     }
 }

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/Script.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/Script.java
@@ -40,6 +40,10 @@ public class Script {
     protected final LocalSession localSession;
     @Getter
     private int changes = 0;
+    @Getter
+    private long progressStartPercentage = 0L;
+    @Getter
+    private long progressEndPercentage = 100L;
 
 
     public Script(Player player, GeneratorComponent generatorComponent) {
@@ -56,10 +60,17 @@ public class Script {
 
     protected void finish(Block[][][] blocks, List<Vector> points) {
         createSelection(points);
-        //setGmask(null);
 
         GeneratorModule.getInstance().getGeneratorCommands().add(new Command(this, blocks));
-        GeneratorModule.getInstance().getPlayerHistory(getPlayer()).addHistoryEntry(new History.HistoryEntry(getGeneratorComponent().getGeneratorType(), this));
+        GeneratorModule.getInstance().getPlayerHistory(getPlayer()).addHistoryEntry(new HistoryEntry(getGeneratorComponent().getGeneratorType(), this));
+    }
+
+    protected void setProgressRange(long startPercentage, long endPercentage) {
+        if (startPercentage < 0L || endPercentage > 100L || startPercentage > endPercentage)
+            throw new IllegalArgumentException("Progress range must be between 0 and 100 and start before end");
+
+        this.progressStartPercentage = startPercentage;
+        this.progressEndPercentage = endPercentage;
     }
 
 
@@ -108,6 +119,19 @@ public class Script {
      */
     public void createCommand(String command) {
         operations.add(new Operation(command));
+    }
+
+    /**
+     * Adds a command to the operation list and counts it as one undoable change.
+     *
+     * Use this for generator commands that actually modify blocks, such as //line,
+     * //set or //replace. Do not use this for pure selection commands.
+     *
+     * @param command The command to add
+     */
+    public void createUndoableCommand(String command) {
+        operations.add(new Operation(command));
+        changes++;
     }
 
     /**
@@ -238,6 +262,18 @@ public class Script {
         replaceBlocks(new BlockState[]{from}, new BlockState[]{to});
     }
 
+    public void setBlockStatesAtPositions(List<Vector> positions, List<BlockState> blockStates) {
+        if (positions.size() != blockStates.size())
+            throw new IllegalArgumentException("Position and BlockState lists must have the same size");
+
+        operations.add(new Operation(
+                Operation.OperationType.SET_BLOCKSTATES_AT_POSITIONS,
+                positions.toArray(new Vector[0]),
+                blockStates.toArray(new BlockState[0])
+        ));
+        changes += positions.size();
+    }
+
     /**
      * Set blocks with a mask.
      * It creates a new Operation with type SET_BLOCKS_WITH_EXPRESSION_MASK and adds it to the list of operations to execute.
@@ -345,9 +381,8 @@ public class Script {
      * @param matchElevation Whether the elevation of the points should be matched to the region
      */
     public void drawCurveWithMask(List<String> masks, List<Vector> points, BlockState[] blocks, boolean matchElevation) {
-        operations.add(new Operation(Operation.OperationType.DRAW_CURVE_WITH_MASKS, masks.toArray(new String[0]),
-                points.toArray(new Vector[0]), blocks, matchElevation));
-        changes += masks.size();
+        operations.add(new Operation(Operation.OperationType.DRAW_CURVE_WITH_MASKS, masks.toArray(new String[0]), points.toArray(new Vector[0]), blocks, matchElevation));
+        changes += Math.max(1, masks.size());
     }
 
     public void drawCurveWithMask(List<String> masks, List<Vector> points, XMaterial[] blocks, boolean matchElevation) {
@@ -382,11 +417,9 @@ public class Script {
      * @param blocks         The block states to set the blocks to
      * @param matchElevation Whether the elevation of the points should be matched to the region
      */
-    public void drawPolyLineWithMask(List<String> masks, List<Vector> points, BlockState[] blocks, boolean matchElevation,
-                                     boolean connectLineEnds) {
-        operations.add(new Operation(Operation.OperationType.DRAW_POLY_LINE_WITH_MASKS, masks.toArray(new String[0]),
-                points.toArray(new Vector[0]), blocks, matchElevation, connectLineEnds));
-        changes += masks.size();
+    public void drawPolyLineWithMask(List<String> masks, List<Vector> points, BlockState[] blocks, boolean matchElevation, boolean connectLineEnds) {
+        operations.add(new Operation(Operation.OperationType.DRAW_POLY_LINE_WITH_MASKS, masks.toArray(new String[0]), points.toArray(new Vector[0]), blocks, matchElevation, connectLineEnds));
+        changes += Math.max(1, masks.size());
     }
 
     public void drawPolyLineWithMask(List<String> masks, List<Vector> points, XMaterial[] blocks, boolean matchElevation,
@@ -426,9 +459,8 @@ public class Script {
      * @param matchElevation Whether the elevation of the points should be matched to the region
      */
     public void drawLineWithMask(List<String> masks, Vector point1, Vector point2, BlockState[] blocks, boolean matchElevation) {
-        operations.add(new Operation(Operation.OperationType.DRAW_LINE_WITH_MASKS, masks.toArray(new String[0]), point1, point2
-                , blocks, matchElevation));
-        changes += masks.size();
+        operations.add(new Operation(Operation.OperationType.DRAW_LINE_WITH_MASKS, masks.toArray(new String[0]), point1, point2, blocks, matchElevation));
+        changes += Math.max(1, masks.size());
     }
 
     public void drawLineWithMask(List<String> masks, Vector point1, Vector point2, XMaterial[] blocks, boolean matchElevation) {
@@ -451,5 +483,9 @@ public class Script {
 
     public void drawLine(Vector point1, Vector point2, XMaterial block, boolean matchElevation) {
         drawLineWithMask(new ArrayList<>(), point1, point2, new XMaterial[]{block}, matchElevation);
+    }
+
+    public void drawLine(Vector point1, Vector point2, BlockState[] blocks, boolean matchElevation) {
+        drawLineWithMask(new ArrayList<>(), point1, point2, blocks, matchElevation);
     }
 }

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/Settings.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/generator/model/Settings.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 import net.buildtheearth.buildteamtools.modules.generator.components.field.CropStage;
 import net.buildtheearth.buildteamtools.modules.generator.components.field.CropType;
 import net.buildtheearth.buildteamtools.modules.generator.components.house.RoofType;
+import net.buildtheearth.buildteamtools.modules.generator.components.rail.RailType;
 import net.buildtheearth.buildteamtools.modules.generator.components.tree.TreeWidth;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -85,6 +86,9 @@ public abstract class Settings {
                     break;
                 case CROP_STAGE:
                     valueStr = new StringBuilder(((CropStage) valueObject).getIdentifier());
+                    break;
+                case RAIL_TYPE:
+                    valueStr = new StringBuilder(((RailType) valueObject).getIdentifier());
                     break;
                 case TREE_WIDTH:
                     valueStr = new StringBuilder(((TreeWidth) valueObject).getName());

--- a/src/main/java/net/buildtheearth/buildteamtools/utils/io/ConfigPaths.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/utils/io/ConfigPaths.java
@@ -1,6 +1,9 @@
 package net.buildtheearth.buildteamtools.utils.io;
 
-public abstract class ConfigPaths {
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class ConfigPaths {
 
     // General Behaviour
     public static final String LANGUAGE = "language";
@@ -13,6 +16,24 @@ public abstract class ConfigPaths {
 
     public static final String DISABLED_MODULES = "disabled-modules";
 
+    @UtilityClass
+    public static class Generator {
+
+        @UtilityClass
+        public static class Rail {
+
+            private static final String PREFIX = "rail.";
+
+            public static final String MAX_CONTROL_POINTS = PREFIX + "max-control-points";
+            public static final String MAX_PATH_POINTS = PREFIX + "max-path-points";
+            public static final String MAX_BLOCK_PLACEMENTS = PREFIX + "max-block-placements";
+            public static final String MAX_PREPARED_REGION_VOLUME = PREFIX + "max-prepared-region-volume";
+            public static final String MAX_PREPARED_REGION_AXIS_LENGTH = PREFIX + "max-prepared-region-axis-length";
+            public static final String BLOCK_PLACEMENT_BATCH_SIZE = PREFIX + "block-placement-batch-size";
+        }
+    }
+
+    @UtilityClass
     public static class Navigation {
 
         // Navigator.Item
@@ -53,6 +74,7 @@ public abstract class ConfigPaths {
         public static final String RGC_LOCAL_DB_PATH = RGC_LOCAL_DB + "path";
     }
 
+    @UtilityClass
     public static class PlotSystem {
 
         // Data Mode

--- a/src/main/java/net/buildtheearth/buildteamtools/utils/io/ConfigUtil.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/utils/io/ConfigUtil.java
@@ -32,7 +32,8 @@ import java.nio.file.Paths;
 public enum ConfigUtil {
     MAIN,
     PLOTSYSTEM,
-    NAVIGATION;
+    NAVIGATION,
+    GENERATOR;
 
     private static ConfigurationUtil configUtilInstance;
 
@@ -40,9 +41,10 @@ public enum ConfigUtil {
         if (configUtilInstance != null) return;
 
         configUtilInstance = new ConfigurationUtil(new ConfigurationUtil.ConfigFile[]{
-                new ConfigurationUtil.ConfigFile(Paths.get("config.yml"), 1.4, false),
+                new ConfigurationUtil.ConfigFile(Paths.get("config.yml"), 1.5, false),
                 new ConfigurationUtil.ConfigFile(Paths.get("modules", "plotsystem", "config.yml"), 1.6, false),
                 new ConfigurationUtil.ConfigFile(Paths.get("modules", "navigation", "config.yml"), 1.7, false),
+                new ConfigurationUtil.ConfigFile(Paths.get("modules", "generator", "config.yml"), 1.0, false),
         });
     }
 

--- a/src/main/resources/modules/generator/config.yml
+++ b/src/main/resources/modules/generator/config.yml
@@ -1,0 +1,19 @@
+# ----------------------------------------------------------------------------------------------
+# |                 BuildTeamTools - Generator Module - by BuildTheEarth
+# ----------------------------------------------------------------------------------------------
+# | [Github Repo]           https://github.com/BuildTheEarth/BuildTeamTools
+# | [Config Documentation]  https://resources.buildtheearth.net/doc/configuration-tpEHSZ6Zt2
+# | [Contacts - Discord]    BTE Development Hub, @zoriot
+# ----------------------------------------------------------------------------------------------
+
+rail:
+  # Conservative defaults for a 4 GB server. Lower these if rail generation is too heavy for your server.
+  max-control-points: 1000
+  max-path-points: 24000
+  max-block-placements: 150000
+  max-prepared-region-volume: 1500000
+  max-prepared-region-axis-length: 1024
+  block-placement-batch-size: 750
+
+# NOTE: Do not change
+config-version: 1.0


### PR DESCRIPTION
## Summary
Adds an initial implementation of the rail generator and re-enables `/gen rail`.

## Changes
- Enables the rail generator command again.
- Builds a rail path from WorldEdit selection points.
- Places center and side blocks for generated rail tracks.
- Adds rail generator help handling.
- Adds support for direct block placement operations.
- Extends generator history so rail generation can be undone/redone.

## Milanote
https://app.milanote.com/1WgUAs1mA492a6?p=9H9SRXRJA3f

