### PR TITLE
✨ Add btt.global.autotpll permission

### DIFF
--- a/src/main/java/net/buildtheearth/buildteamtools/modules/navigation/components/tpll/listeners/TpllListener.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/navigation/components/tpll/listeners/TpllListener.java
@@ -7,6 +7,7 @@ import net.buildtheearth.buildteamtools.modules.navigation.NavigationModule;
 import net.buildtheearth.buildteamtools.modules.network.NetworkModule;
 import net.buildtheearth.buildteamtools.modules.network.api.OpenStreetMapAPI;
 import net.buildtheearth.buildteamtools.modules.network.model.BuildTeam;
+import net.buildtheearth.buildteamtools.modules.network.model.Permissions;
 import net.buildtheearth.buildteamtools.modules.network.model.Region;
 import net.buildtheearth.model.GeographicalCoordinate;
 import org.bukkit.event.EventHandler;
@@ -37,6 +38,8 @@ public class TpllListener implements Listener {
     public void onTpll(PlayerCommandPreprocessEvent event) {
         // Check if the NavigationModule is enabled
         if (!NavigationModule.getInstance().isEnabled()) return;
+
+        if (!event.getPlayer().hasPermission(Permissions.AUTO_TPLL)) return;
 
         // Check if the command is a TPLL command
         if (!isTpllCommand(event)) return;

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/network/model/Permissions.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/network/model/Permissions.java
@@ -32,4 +32,6 @@ public class Permissions {
 
     public static final String NOTIFY_UPDATE = "btt.notify.update";
 
+    public static final String AUTO_TPLL = "btt.global.autotpll";
+
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -51,6 +51,7 @@ permissions:
       btt.navigator.use: true
       btt.warp.use: true
       btt.bp.use: true
+      btt.global.autotpll: true
   btt.permpack.builder:
     description: Contains all permissions for builders / trusted players
     default: op


### PR DESCRIPTION
- Introduced `Permissions.AUTO_TPLL` to restrict global TPLL usage based on player permissions.
- Updated `plugin.yml` with `btt.global.autotpll` permission.