### PR TITLE
fix(permissions): centralize block palette permissions

### DIFF
--- a/src/main/java/net/buildtheearth/buildteamtools/modules/miscellaneous/blockpalettegui/ChoosePaletteMenu.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/miscellaneous/blockpalettegui/ChoosePaletteMenu.java
@@ -2,6 +2,7 @@ package net.buildtheearth.buildteamtools.modules.miscellaneous.blockpalettegui;
 
 import com.alpsbte.alpslib.utils.item.Item;
 import com.cryptomorin.xseries.XMaterial;
+import net.buildtheearth.buildteamtools.modules.network.model.Permissions;
 import net.buildtheearth.buildteamtools.utils.menus.AbstractMenu;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -19,7 +20,6 @@ public class ChoosePaletteMenu extends AbstractMenu {
 
     private static final int BACK_SLOT = 36;
     private static final int ADD_PALETTE_SLOT = 44;
-    private static final String EDIT_PERMISSION = "btt.bp.edit";
 
     private static final String BACK_HEAD =
             "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90"
@@ -226,7 +226,7 @@ public class ChoosePaletteMenu extends AbstractMenu {
 
     private boolean hasEditPermission() {
         try {
-            return getMenuPlayer().hasPermission(EDIT_PERMISSION);
+            return getMenuPlayer().hasPermission(Permissions.BLOCK_PALETTE_EDIT);
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/miscellaneous/blockpalettegui/CreatePaletteMenu.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/miscellaneous/blockpalettegui/CreatePaletteMenu.java
@@ -4,6 +4,7 @@ import com.alpsbte.alpslib.utils.item.Item;
 import com.cryptomorin.xseries.XMaterial;
 import io.papermc.paper.event.player.AsyncChatEvent;
 import lombok.Getter;
+import net.buildtheearth.buildteamtools.modules.network.model.Permissions;
 import net.buildtheearth.buildteamtools.utils.menus.AbstractMenu;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
@@ -44,7 +45,6 @@ public class CreatePaletteMenu extends AbstractMenu {
 
     private static final int MAX_NAME_LENGTH = 32;
     private static final int MAX_DESCRIPTION_LENGTH = 256;
-    private static final String EDIT_PERMISSION = "btt.bp.edit";
 
     private final BlockPaletteManager manager;
     private final JavaPlugin plugin;
@@ -162,7 +162,7 @@ public class CreatePaletteMenu extends AbstractMenu {
 
         // Apply
         getMenu().getSlot(APPLY_SLOT).setClickHandler((p, i) -> {
-            if (!p.hasPermission(EDIT_PERMISSION)) {
+            if (!p.hasPermission(Permissions.BLOCK_PALETTE_EDIT)) {
                 p.sendMessage("§cYou do not have permission to create palettes.");
                 return;
             }

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/miscellaneous/blockpalettegui/EditPaletteMenu.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/miscellaneous/blockpalettegui/EditPaletteMenu.java
@@ -3,6 +3,7 @@ package net.buildtheearth.buildteamtools.modules.miscellaneous.blockpalettegui;
 import com.alpsbte.alpslib.utils.item.Item;
 import com.cryptomorin.xseries.XMaterial;
 import io.papermc.paper.event.player.AsyncChatEvent;
+import net.buildtheearth.buildteamtools.modules.network.model.Permissions;
 import net.buildtheearth.buildteamtools.utils.menus.AbstractMenu;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.Bukkit;
@@ -42,7 +43,6 @@ public class EditPaletteMenu extends AbstractMenu {
 
     private static final int MAX_NAME_LENGTH = 32;
     private static final int MAX_DESCRIPTION_LENGTH = 256;
-    private static final String EDIT_PERMISSION = "btt.bp.edit";
 
     private final BlockPaletteManager manager;
     private final JavaPlugin plugin;
@@ -122,7 +122,7 @@ public class EditPaletteMenu extends AbstractMenu {
     protected void setItemClickEventsAsync() {
         // Name
         getMenu().getSlot(NAME_SLOT).setClickHandler((p, i) -> {
-            if (!p.hasPermission(EDIT_PERMISSION)) {
+            if (!p.hasPermission(Permissions.BLOCK_PALETTE_EDIT)) {
                 p.sendMessage("§cYou do not have permission to edit palettes.");
                 return;
             }
@@ -140,7 +140,7 @@ public class EditPaletteMenu extends AbstractMenu {
 
         // Description
         getMenu().getSlot(DESCRIPTION_SLOT).setClickHandler((p, i) -> {
-            if (!p.hasPermission(EDIT_PERMISSION)) {
+            if (!p.hasPermission(Permissions.BLOCK_PALETTE_EDIT)) {
                 p.sendMessage("§cYou do not have permission to edit palettes.");
                 return;
             }
@@ -158,7 +158,7 @@ public class EditPaletteMenu extends AbstractMenu {
 
         // Blocks
         getMenu().getSlot(BLOCKS_SLOT).setClickHandler((p, i) -> {
-            if (!p.hasPermission(EDIT_PERMISSION)) {
+            if (!p.hasPermission(Permissions.BLOCK_PALETTE_EDIT)) {
                 p.sendMessage("§cYou do not have permission to edit palettes.");
                 return;
             }
@@ -175,7 +175,7 @@ public class EditPaletteMenu extends AbstractMenu {
 
         // Delete
         getMenu().getSlot(DELETE_SLOT).setClickHandler((p, i) -> {
-            if (!p.hasPermission(EDIT_PERMISSION)) {
+            if (!p.hasPermission(Permissions.BLOCK_PALETTE_EDIT)) {
                 p.sendMessage("§cYou do not have permission to delete palettes.");
                 return;
             }
@@ -201,7 +201,7 @@ public class EditPaletteMenu extends AbstractMenu {
 
         // Apply
         getMenu().getSlot(APPLY_SLOT).setClickHandler((p, i) -> {
-            if (!p.hasPermission(EDIT_PERMISSION)) {
+            if (!p.hasPermission(Permissions.BLOCK_PALETTE_EDIT)) {
                 p.sendMessage("§cYou do not have permission to edit palettes.");
                 return;
             }

--- a/src/main/java/net/buildtheearth/buildteamtools/modules/network/model/Permissions.java
+++ b/src/main/java/net/buildtheearth/buildteamtools/modules/network/model/Permissions.java
@@ -17,6 +17,9 @@ public class Permissions {
     public static final String GENERATOR_USE = "btt.generator.use";
 
 
+    public static final String BLOCK_PALETTE_EDIT = "btt.bp.edit";
+
+
     public static final String NAVIGATOR_USE = "btt.navigator.use";
 
 


### PR DESCRIPTION
## Summary
- Added the block palette edit permission to the central `Permissions` class
- Replaced local `btt.bp.edit` constants in block palette menus
- Confirmed the rail generator already uses the centralized generator permission

## Testing
- Ran `./gradlew compileJava`