### PR TITLE
🐛 Use Custom fork for 1.21.4 java remapper support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,27 +10,18 @@ plugins {
 
 repositories {
     mavenCentral()
-    // mavenLocal() // NEVER use in Production/Commits!
     maven("https://repo.papermc.io/repository/maven-public/")
-
     maven("https://maven.buildtheearth.net/releases") // BuildTheEarth Projection
-
     maven("https://mvn.alps-bte.com/repository/alps-bte/") // AlpsLib
-
     maven("https://maven.enginehub.org/repo/") // WorldEdit
-
-    maven("https://mvn.wesjd.net/") // Anvilgui
-
+    //maven("https://mvn.wesjd.net/") // Anvilgui - includes 26.1 module which is build with Java 25, what breaks the Plugin Remapper on Paper 1.21.4 see https://github.com/WesJD/AnvilGUI/issues/408
     maven("https://repo.bluecolored.de/releases") // BlueMap
-
     maven("https://repo.essentialsx.net/releases/")
-
-    // Alps Lib Geo - can be removed once https://github.com/AlpsBTE/Alps-Lib/pull/17 is merged & version is set to 1.0.0
+    // Anvilgui + Alps Lib Geo (for geo it can be removed once https://github.com/AlpsBTE/Alps-Lib/pull/17 is merged & version is set to 1.0.0)
     maven("https://mvn.alps-bte.com/repository/alps-bte-snapshots/")
-
     maven("https://repo.lushplugins.org/releases") // PluginUpdater
-
     maven("https://jitpack.io") // Clipper2
+    //mavenLocal() // NEVER use in Production/Commits!
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ alpslib-utils = "1.5.0"
 # https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/alpslib/alpslib-geo/
 alpslib-geo = "1.0.0-SNAPSHOT"
 # https://github.com/WesJD/AnvilGUI https://mvn.wesjd.net/
-anvilgui = "1.10.13-SNAPSHOT"
+anvilgui = "1.10.14-SNAPSHOT"
 # Ref: https://github.com/BlueMap-Minecraft/BlueMapAPI - Newer Versions require Java 25
 bluemap-api = "2.7.8"
 # https://central.sonatype.com/artifact/org.bstats/bstats-bukkit


### PR DESCRIPTION
- Bumped `anvilgui` version to 1.10.14-SNAPSHOT in `libs.versions.toml`.
- Commented out AnvilGUI repository due to plugin remapper issues with Java 25 on Paper 1.21.4.
- See https://github.com/Zoriot/AnvilGUI
- Support for 26.2 in AnvilGui